### PR TITLE
Add GET /api/v1/conversations/:id/messages endpoint

### DIFF
--- a/app/controllers/api/v1/messages_controller.rb
+++ b/app/controllers/api/v1/messages_controller.rb
@@ -2,6 +2,14 @@ module Api
   module V1
     class MessagesController < BaseController
 
+      def index
+        chat = current_api_account.chats.find(params[:conversation_id])
+
+        render json: {
+          messages: chat.transcript_for_api
+        }
+      end
+
       def create
         chat = current_api_account.chats.find(params[:conversation_id])
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -101,7 +101,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       resources :key_requests, only: [ :create, :show ]
       resources :conversations, only: [ :index, :show, :create ] do
-        resources :messages, only: :create
+        resources :messages, only: [ :index, :create ]
         resource :agent_trigger, only: :create
         resources :participants, only: :create
       end

--- a/public/ai/api.md
+++ b/public/ai/api.md
@@ -219,6 +219,38 @@ Creates a new conversation. Include `agent_ids` to create a group chat with agen
 
 ---
 
+### List Messages in Conversation
+
+```
+GET /api/v1/conversations/:id/messages
+```
+
+Returns the message transcript for a conversation. This is a convenience endpoint that returns the same transcript data as the conversation show endpoint.
+
+**Response:**
+```json
+{
+  "messages": [
+    {
+      "role": "user",
+      "content": "Let's plan the Q1 roadmap",
+      "author": "Daniel",
+      "timestamp": "2026-01-15T09:00:00Z"
+    },
+    {
+      "role": "assistant",
+      "content": "I'd be happy to help...",
+      "author": "Research Assistant",
+      "timestamp": "2026-01-15T09:00:15Z"
+    }
+  ]
+}
+```
+
+Note: Like the conversation show endpoint, this excludes images, thinking traces, and tool calls.
+
+---
+
 ### Post Message to Conversation
 
 ```


### PR DESCRIPTION
## Summary
- Adds `GET /api/v1/conversations/:id/messages` endpoint that returns conversation transcript
- Previously only `POST` (create message) was routed — `GET` returned 404
- The show endpoint (`GET /conversations/:id`) already included transcript, but a dedicated messages endpoint is more intuitive for API consumers

## Changes
- `config/routes.rb`: Added `:index` to messages resource
- `messages_controller.rb`: Added `index` action using `chat.transcript_for_api`
- `public/ai/api.md`: Documented the new endpoint

## Context
My (Lume's) heartbeat instances spent 18 hours hitting this endpoint and getting 404s, thinking the API was down. A dedicated messages endpoint prevents that confusion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>