### PR TITLE
Add hosted agent runtime observability

### DIFF
--- a/agent-runtime/Dockerfile
+++ b/agent-runtime/Dockerfile
@@ -23,12 +23,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Pin to a specific chaos commit SHA for reproducibility.
-# 3c94f94e: runtime observability built on top of the merged Anthropic prompt
+# a7e98d33: runtime observability built on top of the merged Anthropic prompt
 # caching support. Until the observability PR is merged upstream, pin the
 # reviewed fork commit so runtime images actually emit the contract consumed by
 # trigger_shim.py and HelixKit.
 ARG CHAOS_REPO=https://github.com/swombat/chaos.git
-ARG CHAOS_REF=3c94f94e117bfd68d4db03d3a1e7d7eb4cb91c6d
+ARG CHAOS_REF=a7e98d33fd4e22929eac5a1926d3a0f1f37f2809
 
 WORKDIR /build
 RUN git clone --filter=blob:none ${CHAOS_REPO} chaos \

--- a/agent-runtime/Dockerfile
+++ b/agent-runtime/Dockerfile
@@ -10,7 +10,7 @@
 # =============================================================================
 # Stage 1 — pull and build chaos. Source tree is discarded after the binary copies.
 # =============================================================================
-FROM rust:1.95-bookworm AS builder
+FROM rust:1.97-bookworm AS builder
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -23,10 +23,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Pin to a specific chaos commit SHA for reproducibility.
-# cbd48916: master with PR #13 merged (Anthropic prompt caching in the parrot
-# provider — cache_control + cache-read/creation accounting in TokenUsage).
-ARG CHAOS_REPO=https://github.com/seuros/chaos.git
-ARG CHAOS_REF=cbd489164327e1bcdfc374cbc7cdeb5249fb1788
+# 3c94f94e: runtime observability built on top of the merged Anthropic prompt
+# caching support. Until the observability PR is merged upstream, pin the
+# reviewed fork commit so runtime images actually emit the contract consumed by
+# trigger_shim.py and HelixKit.
+ARG CHAOS_REPO=https://github.com/swombat/chaos.git
+ARG CHAOS_REF=3c94f94e117bfd68d4db03d3a1e7d7eb4cb91c6d
 
 WORKDIR /build
 RUN git clone --filter=blob:none ${CHAOS_REPO} chaos \

--- a/agent-runtime/trigger_shim.py
+++ b/agent-runtime/trigger_shim.py
@@ -43,12 +43,12 @@ Persistent-session behaviour (when `persistent_session` is true):
       re-injection, no journal re-read.
     - The session rolls (fresh start) on: provider/model change,
       identity-file change, or any resume failure.
-    - The response gains `chaos_session_id`, `session_resumed`,
-      `fresh_fallback`, `session_roll_reason`, and `usage`
-      {input_tokens, cached_input_tokens, output_tokens}.
+    - The response gains a versioned `telemetry` object describing the runtime,
+      session decision, prompt sizes, and invocation-local usage. Existing
+      top-level session and usage fields remain during migration.
 
-Without `persistent_session`, behaviour is byte-identical to the legacy shim:
-one fresh non-persisted-mapping `chaos exec` per trigger.
+Without `persistent_session`, each trigger still runs one fresh Chaos process
+without a sidecar mapping, but JSON output is enabled so usage is observable.
 
 Env vars (read at startup):
     AGENT_ID                  stable identifier for this agent
@@ -98,7 +98,11 @@ SHIM_PORT = int(os.environ.get("SHIM_PORT", "4000"))
 CHAOS_BIN = os.environ.get("CHAOS_BIN", "/usr/local/bin/chaos")
 CHAOS_HOME = Path(os.environ.get("CHAOS_HOME", str(Path.home() / ".chaos")))
 CHAOS_TIMEOUT_SECS = int(os.environ.get("CHAOS_TIMEOUT_SECS", "600"))
+CHAOS_ANTHROPIC_CACHE_TTL = os.environ.get("CHAOS_ANTHROPIC_CACHE_TTL")
 SESSION_MAP_DIR = CHAOS_HOME / "helixkit-sessions"
+SHIM_TELEMETRY_SCHEMA_VERSION = 1
+SIDECAR_SCHEMA_VERSION = 2
+SUPPORTED_CHAOS_TELEMETRY_SCHEMA_VERSION = 1
 IDENTITY_FINGERPRINT_FILES = [
     "soul.md",
     "runtime-instructions.md",
@@ -109,6 +113,15 @@ IDENTITY_FILE_LIMIT = 80_000
 JOURNAL_MOST_RECENT_LIMIT = 12_000
 JOURNAL_MOST_RECENT_TAIL = 10_000
 JOURNAL_TOTAL_LIMIT = 16_000
+USAGE_FIELDS = (
+    "input_tokens",
+    "uncached_input_tokens",
+    "cache_creation_input_tokens",
+    "cache_read_input_tokens",
+    "output_tokens",
+    "reasoning_output_tokens",
+    "provider_request_count",
+)
 
 logging.basicConfig(
     level=logging.INFO,
@@ -169,25 +182,73 @@ def trigger():
 
 
 def legacy_trigger(session_id, prompt, model, timeout_secs, provider=None):
-    """One fresh chaos exec per trigger — the original shim behaviour, unchanged."""
-    full_prompt = build_prompt(prompt)
+    """Run a fresh, unmapped Chaos process while still capturing JSON telemetry."""
+    provider = provider or AGENT_PROVIDER
+    full_prompt, prompt_components = build_prompt_with_components(prompt)
+    prompt_info = prompt_telemetry(
+        full_prompt=full_prompt,
+        delta_prompt=None,
+        selected_prompt=full_prompt,
+        mode="full",
+        components=prompt_components,
+    )
 
     try:
-        result = run_chaos(model, timeout_secs, full_prompt, json_output=False, provider=provider)
-    except subprocess.TimeoutExpired:
+        result = run_chaos(model, timeout_secs, full_prompt, json_output=True, provider=provider)
+    except subprocess.TimeoutExpired as error:
         log.error(f"chaos exec timed out after {timeout_secs}s")
-        return jsonify({"status": "timeout", "session_id": session_id, "timeout_secs": timeout_secs}), 504
+        return timeout_response(
+            session_id=session_id,
+            timeout_secs=timeout_secs,
+            runtime=runtime_telemetry(provider, model, timeout_secs),
+            session=session_telemetry(
+                session_id=session_id,
+                mapping_found=False,
+                resume_attempted=False,
+                outcome="failed",
+                roll_reason=None,
+                changed_identity_files=[],
+                prior_process_id=None,
+                process_id=None,
+                record=None,
+                trigger_sequence=1,
+                persistent_requested=False,
+            ),
+            prompt=prompt_info,
+            timeout_error=error,
+            invocation_text=full_prompt,
+            resumed=False,
+            fresh_fallback=False,
+        )
 
-    response = {
-        "status": "ok" if result.returncode == 0 else "error",
-        "session_id": session_id,
-        "returncode": result.returncode,
-        "stdout": _tail(result.stdout, 4000),
-        "stderr": _tail(result.stderr, 4000),
-        "full_invocation_text": full_prompt,
-    }
-    log.info(f"trigger done session_id={session_id} rc={result.returncode}")
-    return jsonify(response), (200 if result.returncode == 0 else 500)
+    events = parse_events(result.stdout)
+    usage = invocation_usage(None, events)
+    outcome = "legacy_fresh" if result.returncode == 0 else "failed"
+    return instrumented_response(
+        session_id,
+        result,
+        events,
+        full_prompt,
+        usage=usage,
+        runtime=runtime_telemetry(provider, model, timeout_secs, events),
+        session=session_telemetry(
+            session_id=session_id,
+            mapping_found=False,
+            resume_attempted=False,
+            outcome=outcome,
+            roll_reason=None,
+            changed_identity_files=[],
+            prior_process_id=None,
+            process_id=events["process_id"],
+            record=None,
+            trigger_sequence=1,
+            persistent_requested=False,
+        ),
+        prompt=prompt_info,
+        resumed=False,
+        fresh_fallback=False,
+        roll=None,
+    )
 
 
 def persistent_trigger(session_id, prompt, request_delta, model, timeout_secs, provider=None):
@@ -200,12 +261,36 @@ def persistent_trigger(session_id, prompt, request_delta, model, timeout_secs, p
     lock = _lock_for(session_id)
     if not lock.acquire(blocking=False):
         log.warning(f"session busy session_id={session_id}")
-        return jsonify({"status": "already_running", "session_id": session_id}), 409
+        return jsonify({
+            "status": "already_running",
+            "session_id": session_id,
+            "telemetry": build_telemetry(
+                runtime=runtime_telemetry(provider or AGENT_PROVIDER, model, timeout_secs),
+                session={
+                    "logical_session_id": session_id,
+                    "persistent_requested": True,
+                    "mapping_found": None,
+                    "resume_attempted": False,
+                    "outcome": "already_running",
+                    "roll_reason": None,
+                    "changed_identity_files": [],
+                    "prior_chaos_process_id": None,
+                    "chaos_process_id": None,
+                    "trigger_sequence": None,
+                    "session_age_seconds": None,
+                },
+                prompt=None,
+                usage=None,
+            ),
+        }), 409
 
     try:
         provider = provider or AGENT_PROVIDER
+        prior_attempt = None
         record = load_session_record(session_id)
-        roll = roll_reason(record, model, provider) if record else None
+        mapping_found = record is not None
+        prior_process_id = record.get("chaos_process_id") if record else None
+        roll, changed_identity_files = roll_decision(record, model, provider) if record else (None, [])
         if record and roll:
             log.info(f"rolling session session_id={session_id} reason={roll}")
             retire_session_record(session_id, reason=roll)
@@ -213,28 +298,74 @@ def persistent_trigger(session_id, prompt, request_delta, model, timeout_secs, p
 
         if record:
             resume_prompt = request_delta or prompt
+            prompt_info = prompt_telemetry(
+                full_prompt=None,
+                delta_prompt=request_delta,
+                selected_prompt=resume_prompt,
+                mode="delta",
+                components=None,
+            )
             try:
                 result = run_chaos(
                     model, timeout_secs, resume_prompt,
                     json_output=True, resume_id=record["chaos_process_id"], provider=provider,
                 )
-            except subprocess.TimeoutExpired:
+            except subprocess.TimeoutExpired as error:
                 # The subprocess is killed on timeout, so the persisted session
                 # may contain only part of this turn. Retire the ambiguous
                 # mapping: the next trigger will use the full prompt instead of
                 # replaying the same delta into a possibly half-written turn.
                 log.error(f"chaos resume timed out after {timeout_secs}s session_id={session_id}")
                 retire_session_record(session_id, reason="resume-timeout")
-                return jsonify({"status": "timeout", "session_id": session_id, "timeout_secs": timeout_secs}), 504
+                return timeout_response(
+                    session_id=session_id,
+                    timeout_secs=timeout_secs,
+                    runtime=runtime_telemetry(provider, model, timeout_secs),
+                    session=session_telemetry(
+                        session_id=session_id,
+                        mapping_found=True,
+                        resume_attempted=True,
+                        outcome="resume_timeout",
+                        roll_reason="resume-timeout",
+                        changed_identity_files=[],
+                        prior_process_id=prior_process_id,
+                        process_id=prior_process_id,
+                        record=record,
+                    ),
+                    prompt=prompt_info,
+                    timeout_error=error,
+                    usage_record=record,
+                    invocation_text=resume_prompt,
+                    resumed=False,
+                    fresh_fallback=False,
+                )
 
             events = parse_events(result.stdout)
             stale = events["process_id"] != record["chaos_process_id"]
             if result.returncode == 0 and not stale:
-                usage = usage_since(record, events)
-                update_session_record(session_id, record, events, usage)
-                return persistent_response(
+                usage = invocation_usage(record, events)
+                next_sequence = next_trigger_sequence(record)
+                update_session_record(session_id, record, events)
+                return instrumented_response(
                     session_id, result, events, resume_prompt,
-                    usage=usage, resumed=True, fresh_fallback=False, roll=None,
+                    usage=usage,
+                    runtime=runtime_telemetry(provider, model, timeout_secs, events),
+                    session=session_telemetry(
+                        session_id=session_id,
+                        mapping_found=True,
+                        resume_attempted=True,
+                        outcome="resumed",
+                        roll_reason=None,
+                        changed_identity_files=[],
+                        prior_process_id=prior_process_id,
+                        process_id=events["process_id"],
+                        record=record,
+                        trigger_sequence=next_sequence,
+                    ),
+                    prompt=prompt_info,
+                    resumed=True,
+                    fresh_fallback=False,
+                    roll=None,
                 )
 
             log.warning(
@@ -242,24 +373,91 @@ def persistent_trigger(session_id, prompt, request_delta, model, timeout_secs, p
                 f"stale={stale} mapped={record['chaos_process_id']} got={events['process_id']}"
             )
             retire_session_record(session_id, reason="resume-failed")
+            prior_attempt = {
+                "usage": invocation_usage(record, events),
+                "detailed": events["telemetry_status"] == "detailed",
+            }
+            if prior_attempt["detailed"] and result.returncode != 0:
+                prior_attempt["usage"] = dict(prior_attempt["usage"] or {})
+                prior_attempt["usage"]["complete"] = False
             roll = roll or "resume-failed"
+            changed_identity_files = []
 
         # Fresh path: full identity-wrapped prompt, new session, new mapping.
-        full_prompt = build_prompt(prompt)
+        # Build this only after deciding not to resume. Reading journals on a
+        # successful resume is unnecessary work and can make an append appear
+        # to affect a turn whose actual prompt contains only the delta.
+        full_prompt, prompt_components = build_prompt_with_components(prompt)
+        prompt_info = prompt_telemetry(
+            full_prompt=full_prompt,
+            delta_prompt=request_delta,
+            selected_prompt=full_prompt,
+            mode="full",
+            components=prompt_components,
+        )
         try:
             result = run_chaos(model, timeout_secs, full_prompt, json_output=True, provider=provider)
-        except subprocess.TimeoutExpired:
+        except subprocess.TimeoutExpired as error:
             log.error(f"chaos exec timed out after {timeout_secs}s session_id={session_id}")
-            return jsonify({"status": "timeout", "session_id": session_id, "timeout_secs": timeout_secs}), 504
+            outcome = "fresh_fallback" if roll == "resume-failed" else ("rolled" if mapping_found else "failed")
+            return timeout_response(
+                session_id=session_id,
+                timeout_secs=timeout_secs,
+                runtime=runtime_telemetry(provider, model, timeout_secs),
+                session=session_telemetry(
+                    session_id=session_id,
+                    mapping_found=mapping_found,
+                    resume_attempted=(roll == "resume-failed"),
+                    outcome=outcome,
+                    roll_reason=roll,
+                    changed_identity_files=changed_identity_files,
+                    prior_process_id=prior_process_id,
+                    process_id=None,
+                    record=None,
+                    trigger_sequence=1,
+                ),
+                prompt=prompt_info,
+                timeout_error=error,
+                invocation_text=full_prompt,
+                resumed=False,
+                fresh_fallback=(roll == "resume-failed"),
+                roll=roll,
+                prior_attempt=prior_attempt,
+            )
 
         events = parse_events(result.stdout)
-        usage = usage_since(None, events)
+        usage = invocation_usage(None, events)
         if result.returncode == 0 and events["process_id"]:
-            save_session_record(session_id, model, events, usage, provider=provider)
-        return persistent_response(
+            save_session_record(session_id, model, events, provider=provider)
+        if result.returncode != 0:
+            outcome = "failed"
+        elif roll == "resume-failed":
+            outcome = "fresh_fallback"
+        elif mapping_found:
+            outcome = "rolled"
+        else:
+            outcome = "fresh"
+        return instrumented_response(
             session_id, result, events, full_prompt,
-            usage=usage, resumed=False,
-            fresh_fallback=(roll == "resume-failed"), roll=roll,
+            usage=usage,
+            runtime=runtime_telemetry(provider, model, timeout_secs, events),
+            session=session_telemetry(
+                session_id=session_id,
+                mapping_found=mapping_found,
+                resume_attempted=(roll == "resume-failed"),
+                outcome=outcome,
+                roll_reason=roll,
+                changed_identity_files=changed_identity_files,
+                prior_process_id=prior_process_id,
+                process_id=events["process_id"],
+                record=None,
+                trigger_sequence=1,
+            ),
+            prompt=prompt_info,
+            resumed=False,
+            fresh_fallback=(roll == "resume-failed"),
+            roll=roll,
+            prior_attempt=prior_attempt,
         )
     finally:
         lock.release()
@@ -308,11 +506,19 @@ def run_chaos(model, timeout_secs, prompt_text, json_output, resume_id=None, pro
 def parse_events(stdout):
     """Parse `chaos exec --json` JSONL output.
 
-    Returns process_id, the latest cumulative token usage reported by Chaos,
-    and the agent's final message texts (for human-readable diagnostics).
+    Version-1 Chaos telemetry is invocation-local and safe to persist directly.
+    Older events are retained as explicitly legacy cumulative counters so they
+    cannot accidentally populate the new detailed usage fields.
     """
     parsed = {
         "process_id": None,
+        "telemetry_schema_version": None,
+        "telemetry_status": "missing",
+        "usage": None,
+        "session_usage": None,
+        "unsupported_telemetry_schema_version": None,
+        "legacy_cumulative_usage": None,
+        # Compatibility aliases for the old cumulative subtraction path.
         "input_tokens": 0,
         "cached_input_tokens": 0,
         "output_tokens": 0,
@@ -330,11 +536,8 @@ def parse_events(stdout):
         kind = event.get("type")
         if kind == "process.started":
             parsed["process_id"] = event.get("process_id")
-        elif kind == "turn.completed":
-            usage = event.get("usage") or {}
-            parsed["input_tokens"] = int(usage.get("input_tokens") or 0)
-            parsed["cached_input_tokens"] = int(usage.get("cached_input_tokens") or 0)
-            parsed["output_tokens"] = int(usage.get("output_tokens") or 0)
+        elif kind in ("turn.completed", "invocation.completed"):
+            _parse_completion_event(parsed, event)
         elif kind == "item.completed":
             item = event.get("item") or {}
             if item.get("type") == "agent_message" and item.get("text"):
@@ -344,13 +547,96 @@ def parse_events(stdout):
     return parsed
 
 
+def _parse_completion_event(parsed, event):
+    usage = event.get("usage") or {}
+    schema_version = _optional_int(event.get("telemetry_schema_version"))
+    parsed.update({
+        "telemetry_schema_version": schema_version,
+        "telemetry_status": "missing",
+        "usage": None,
+        "session_usage": None,
+        "unsupported_telemetry_schema_version": None,
+        "legacy_cumulative_usage": None,
+        "input_tokens": 0,
+        "cached_input_tokens": 0,
+        "output_tokens": 0,
+    })
+
+    if schema_version is None:
+        legacy = {
+            "input_tokens": _int_or_zero(usage.get("input_tokens")),
+            "cached_input_tokens": _int_or_zero(usage.get("cached_input_tokens")),
+            "output_tokens": _int_or_zero(usage.get("output_tokens")),
+        }
+        if _has_additive_legacy_usage(usage):
+            cache_read = (
+                usage.get("cache_read_input_tokens")
+                if "cache_read_input_tokens" in usage
+                else usage.get("cached_input_tokens")
+            )
+            legacy.update({
+                "uncached_input_tokens": _optional_int(usage.get("uncached_input_tokens")),
+                "cache_creation_input_tokens": _optional_int(usage.get("cache_creation_input_tokens")),
+                "cache_read_input_tokens": _optional_int(cache_read),
+                "reasoning_output_tokens": _optional_int(usage.get("reasoning_output_tokens")),
+                "provider_request_count": _optional_int(usage.get("provider_request_count")),
+            })
+        parsed["telemetry_status"] = "legacy"
+        parsed["legacy_cumulative_usage"] = legacy
+        parsed.update(legacy)
+        return
+
+    if schema_version != SUPPORTED_CHAOS_TELEMETRY_SCHEMA_VERSION:
+        parsed["telemetry_status"] = "unsupported"
+        parsed["unsupported_telemetry_schema_version"] = schema_version
+        return
+
+    if usage.get("scope") != "invocation":
+        parsed["telemetry_status"] = "invalid_scope"
+        return
+
+    parsed["telemetry_status"] = "detailed"
+    parsed["usage"] = normalize_usage(usage)
+    session_usage = event.get("session_usage")
+    if isinstance(session_usage, dict) and session_usage.get("scope") == "process_cumulative":
+        parsed["session_usage"] = normalize_usage(session_usage)
+
+
+def normalize_usage(usage):
+    normalized = {"scope": usage.get("scope")}
+    for field in USAGE_FIELDS:
+        value = usage.get(field)
+        if field == "cache_read_input_tokens" and field not in usage:
+            value = usage.get("cached_input_tokens")
+        normalized[field] = _optional_int(value)
+    if "complete" in usage:
+        normalized["complete"] = usage["complete"] if isinstance(usage["complete"], bool) else None
+    return normalized
+
+
+def invocation_usage(record, events):
+    """Return new invocation-local usage, or a coarse old-runtime fallback."""
+    if events["telemetry_status"] == "detailed":
+        return events["usage"]
+    if events["telemetry_status"] == "legacy":
+        return usage_since(record, events)
+    return None
+
+
 def usage_since(record, events):
-    """Convert Chaos's cumulative process counters into usage for this trigger."""
+    """Compatibility only: subtract old Chaos process-cumulative counters."""
     record = record or {}
     usage = {}
-    for key in ("input_tokens", "cached_input_tokens", "output_tokens"):
+    cumulative_usage = events.get("legacy_cumulative_usage") or {
+        key: events.get(key)
+        for key in ("input_tokens", "cached_input_tokens", "output_tokens")
+    }
+    for key, current_value in cumulative_usage.items():
+        if current_value is None:
+            usage[key] = None
+            continue
         previous = int(record.get(f"cumulative_{key}") or 0)
-        current = int(events.get(key) or 0)
+        current = int(current_value)
         # A future Chaos compaction or accounting change may reset a cumulative
         # counter. Treat the new value as this trigger's usage rather than
         # incorrectly reporting zero forever after the reset.
@@ -358,8 +644,19 @@ def usage_since(record, events):
     return usage
 
 
-def persistent_response(
-    session_id, result, events, invocation_text, usage, resumed, fresh_fallback, roll
+def instrumented_response(
+    session_id,
+    result,
+    events,
+    invocation_text,
+    usage,
+    runtime,
+    session,
+    prompt,
+    resumed,
+    fresh_fallback,
+    roll,
+    prior_attempt=None,
 ):
     # Prefer the agent's own message texts as diagnostics; fall back to raw
     # JSONL tail so failures stay debuggable.
@@ -370,6 +667,23 @@ def persistent_response(
     if events["errors"]:
         stdout_text += "\n\n[events] " + "\n".join(events["errors"])
 
+    telemetry_usage = response_invocation_usage(events, result.returncode)
+    compatibility_usage = compatibility_usage_fields(telemetry_usage or usage)
+    chaos_telemetry_status = events["telemetry_status"]
+    if prior_attempt:
+        compatibility_usage = aggregate_attempt_usage(
+            compatibility_usage_fields(prior_attempt.get("usage")),
+            compatibility_usage,
+        )
+        compatibility_usage = compatibility_usage_fields(compatibility_usage)
+        if prior_attempt.get("detailed") and telemetry_usage is not None:
+            telemetry_usage = aggregate_attempt_usage(prior_attempt.get("usage"), telemetry_usage)
+        else:
+            telemetry_usage = None
+            chaos_telemetry_status = "mixed"
+    if result.returncode != 0:
+        compatibility_usage = dict(compatibility_usage)
+        compatibility_usage["complete"] = False
     response = {
         "status": "ok" if result.returncode == 0 else "error",
         "session_id": session_id,
@@ -380,16 +694,213 @@ def persistent_response(
         "chaos_session_id": events["process_id"],
         "session_resumed": resumed,
         "fresh_fallback": fresh_fallback,
-        "usage": usage,
+        "usage": compatibility_usage,
+        "telemetry": build_telemetry(
+            runtime=runtime,
+            session=session,
+            prompt=prompt,
+            usage=telemetry_usage,
+            session_usage=events["session_usage"],
+            chaos_telemetry_status=chaos_telemetry_status,
+            unsupported_chaos_schema=events["unsupported_telemetry_schema_version"],
+        ),
     }
     if roll:
         response["session_roll_reason"] = roll
     log.info(
         f"trigger done session_id={session_id} rc={result.returncode} resumed={resumed} "
         f"chaos_session={events['process_id']} "
-        f"usage=i{usage['input_tokens']}/c{usage['cached_input_tokens']}/o{usage['output_tokens']}"
+        f"telemetry={events['telemetry_status']} "
+        f"usage=i{compatibility_usage.get('input_tokens')}/"
+        f"c{compatibility_usage.get('cached_input_tokens')}/"
+        f"o{compatibility_usage.get('output_tokens')}"
     )
     return jsonify(response), (200 if result.returncode == 0 else 500)
+
+
+def response_invocation_usage(events, returncode):
+    """Return detailed usage, marking failed shim invocations incomplete."""
+    if events["telemetry_status"] != "detailed":
+        return None
+    usage = dict(events["usage"])
+    if returncode != 0:
+        usage["complete"] = False
+    return usage
+
+
+def compatibility_usage_fields(usage):
+    if not usage:
+        return {}
+    if "cache_read_input_tokens" in usage:
+        return {
+            **usage,
+            "cached_input_tokens": usage.get("cache_read_input_tokens"),
+        }
+    return usage
+
+
+def aggregate_attempt_usage(first, second):
+    """Aggregate all Chaos invocations caused by one HelixKit trigger."""
+    if not first:
+        return second or {}
+    if not second:
+        return first or {}
+
+    aggregate = {"scope": "trigger"}
+    for field in USAGE_FIELDS:
+        left = first.get(field)
+        if field == "cache_read_input_tokens" and left is None:
+            left = first.get("cached_input_tokens")
+        right = second.get(field)
+        if field == "cache_read_input_tokens" and right is None:
+            right = second.get("cached_input_tokens")
+        aggregate[field] = left + right if left is not None and right is not None else None
+
+    complete_values = [usage.get("complete") for usage in (first, second)]
+    aggregate["complete"] = all(value is not False for value in complete_values)
+    return aggregate
+
+
+def build_telemetry(
+    runtime,
+    session,
+    prompt,
+    usage,
+    session_usage=None,
+    chaos_telemetry_status=None,
+    unsupported_chaos_schema=None,
+):
+    telemetry = {
+        "schema_version": SHIM_TELEMETRY_SCHEMA_VERSION,
+        "runtime": runtime,
+        "session": session,
+        "prompt": prompt,
+        "usage": usage,
+    }
+    if session_usage is not None:
+        telemetry["session_usage"] = session_usage
+    if chaos_telemetry_status:
+        telemetry["chaos_telemetry_status"] = chaos_telemetry_status
+    if unsupported_chaos_schema is not None:
+        telemetry["unsupported_chaos_telemetry_schema_version"] = unsupported_chaos_schema
+    return telemetry
+
+
+def runtime_telemetry(provider, model, timeout_secs, events=None):
+    return {
+        "chaos_version": _chaos_version(),
+        "provider": provider,
+        "model": model,
+        "cache_ttl": effective_cache_ttl(provider),
+        "timeout_seconds": timeout_secs,
+        "chaos_telemetry_schema_version": (
+            events.get("telemetry_schema_version") if events else None
+        ),
+    }
+
+
+def effective_cache_ttl(provider):
+    if provider != "anthropic":
+        return "unknown"
+    value = (CHAOS_ANTHROPIC_CACHE_TTL or "").strip().lower()
+    return value if value in ("off", "5m", "1h") else "unknown"
+
+
+def session_telemetry(
+    session_id,
+    mapping_found,
+    resume_attempted,
+    outcome,
+    roll_reason,
+    changed_identity_files,
+    prior_process_id,
+    process_id,
+    record,
+    trigger_sequence=None,
+    persistent_requested=True,
+):
+    return {
+        "logical_session_id": session_id,
+        "persistent_requested": persistent_requested,
+        "mapping_found": mapping_found,
+        "resume_attempted": resume_attempted,
+        "outcome": outcome,
+        "roll_reason": roll_reason,
+        "changed_identity_files": changed_identity_files,
+        "prior_chaos_process_id": prior_process_id,
+        "chaos_process_id": process_id,
+        "sidecar_created_at": record.get("created_at") if record else None,
+        "sidecar_last_finished_at": record.get("last_finished_at") if record else None,
+        "session_age_seconds": _session_age_seconds(record),
+        "trigger_sequence": trigger_sequence,
+    }
+
+
+def timeout_response(
+    session_id,
+    timeout_secs,
+    runtime,
+    session,
+    prompt,
+    timeout_error=None,
+    usage_record=None,
+    invocation_text=None,
+    resumed=False,
+    fresh_fallback=False,
+    roll=None,
+    prior_attempt=None,
+):
+    stdout = _timeout_stream(timeout_error, "stdout")
+    stderr = _timeout_stream(timeout_error, "stderr")
+    events = parse_events(stdout)
+    usage = invocation_usage(usage_record, events)
+    telemetry_usage = response_invocation_usage(events, returncode=1)
+    compatibility_usage = compatibility_usage_fields(telemetry_usage or usage)
+    chaos_telemetry_status = "incomplete"
+    if prior_attempt:
+        compatibility_usage = aggregate_attempt_usage(
+            compatibility_usage_fields(prior_attempt.get("usage")),
+            compatibility_usage,
+        )
+        compatibility_usage = compatibility_usage_fields(compatibility_usage)
+        if prior_attempt.get("detailed") and telemetry_usage is not None:
+            telemetry_usage = aggregate_attempt_usage(prior_attempt.get("usage"), telemetry_usage)
+        else:
+            telemetry_usage = None
+            chaos_telemetry_status = "mixed_incomplete"
+    compatibility_usage["complete"] = False
+
+    runtime = dict(runtime)
+    runtime["chaos_telemetry_schema_version"] = events["telemetry_schema_version"]
+    session = dict(session)
+    if not session.get("chaos_process_id") and events["process_id"]:
+        session["chaos_process_id"] = events["process_id"]
+
+    response = {
+        "status": "timeout",
+        "session_id": session_id,
+        "timeout_secs": timeout_secs,
+        "returncode": None,
+        "stdout": _tail(stdout, 4000),
+        "stderr": _tail(stderr, 4000),
+        "full_invocation_text": invocation_text,
+        "chaos_session_id": session.get("chaos_process_id"),
+        "session_resumed": resumed,
+        "fresh_fallback": fresh_fallback,
+        "usage": compatibility_usage,
+        "telemetry": build_telemetry(
+            runtime=runtime,
+            session=session,
+            prompt=prompt,
+            usage=telemetry_usage,
+            session_usage=events["session_usage"],
+            chaos_telemetry_status=chaos_telemetry_status,
+            unsupported_chaos_schema=events["unsupported_telemetry_schema_version"],
+        ),
+    }
+    if roll:
+        response["session_roll_reason"] = roll
+    return jsonify(response), 504
 
 
 # ----- session sidecar records -----
@@ -414,29 +925,39 @@ def load_session_record(session_id):
     return record
 
 
-def save_session_record(session_id, model, events, usage, provider=None):
+def save_session_record(session_id, model, events, provider=None):
     now = _utcnow_iso()
     record = {
+        "schema_version": SIDECAR_SCHEMA_VERSION,
         "helixkit_session_id": session_id,
         "chaos_process_id": events["process_id"],
         "provider": provider or AGENT_PROVIDER,
         "model": model,
         "created_at": now,
         "last_finished_at": now,
-        "cumulative_input_tokens": events["input_tokens"],
-        "cumulative_cached_input_tokens": events["cached_input_tokens"],
-        "cumulative_output_tokens": events["output_tokens"],
+        "trigger_sequence": 1,
         "identity_fingerprint": identity_fingerprint(),
     }
+    _store_legacy_cumulative_usage(record, events)
     _atomic_write(session_record_path(session_id), record)
 
 
-def update_session_record(session_id, record, events, usage):
+def update_session_record(session_id, record, events):
+    record["schema_version"] = SIDECAR_SCHEMA_VERSION
     record["last_finished_at"] = _utcnow_iso()
-    record["cumulative_input_tokens"] = events["input_tokens"]
-    record["cumulative_cached_input_tokens"] = events["cached_input_tokens"]
-    record["cumulative_output_tokens"] = events["output_tokens"]
+    record["trigger_sequence"] = next_trigger_sequence(record)
+    record["identity_fingerprint"] = identity_fingerprint()
+    _store_legacy_cumulative_usage(record, events)
     _atomic_write(session_record_path(session_id), record)
+
+
+def _store_legacy_cumulative_usage(record, events):
+    legacy = events.get("legacy_cumulative_usage")
+    if not legacy:
+        return
+    for key, value in legacy.items():
+        if value is not None:
+            record[f"cumulative_{key}"] = value
 
 
 def retire_session_record(session_id, reason):
@@ -453,28 +974,60 @@ def retire_session_record(session_id, reason):
             pass
 
 
-def roll_reason(record, model, provider=None):
-    """Reasons to abandon a mapped session and start fresh. None = resume."""
+def roll_decision(record, model, provider=None):
+    """Return (reason, changed identity files); reason None means resume."""
+    schema_version = _optional_int(record.get("schema_version", 1))
+    if schema_version is None or schema_version > SIDECAR_SCHEMA_VERSION:
+        return "sidecar-schema-unsupported", []
     if record.get("provider", AGENT_PROVIDER) != (provider or AGENT_PROVIDER):
-        return "provider-changed"
+        return "provider-changed", []
     if record.get("model") != model:
-        return "model-changed"
-    if record.get("identity_fingerprint") != identity_fingerprint():
-        return "identity-changed"
-    return None
+        return "model-changed", []
+    changed_files = changed_identity_files(record.get("identity_fingerprint") or {})
+    if changed_files:
+        return "identity-changed", changed_files
+    return None, []
+
+
+def roll_reason(record, model, provider=None):
+    """Compatibility wrapper for callers that only need the reason."""
+    reason, _changed_files = roll_decision(record, model, provider)
+    return reason
 
 
 def identity_fingerprint():
-    """mtimes of the injected identity files; a change rolls the session so
-    identity edits propagate at the next turn instead of never."""
+    """Content fingerprints for identity files that require a session roll."""
     fingerprint = {}
     for filename in IDENTITY_FINGERPRINT_FILES:
         path = AGENT_IDENTITY_PATH / filename
         try:
-            fingerprint[filename] = path.stat().st_mtime_ns
+            content = path.read_bytes()
+            fingerprint[filename] = {
+                "sha256": hashlib.sha256(content).hexdigest(),
+                "bytes": len(content),
+            }
         except OSError:
             fingerprint[filename] = None
     return fingerprint
+
+
+def changed_identity_files(previous_fingerprint):
+    current = identity_fingerprint()
+    changed = []
+    for filename in IDENTITY_FINGERPRINT_FILES:
+        previous = previous_fingerprint.get(filename)
+        if isinstance(previous, int):
+            # Schema-v1 sidecars stored mtimes. They can safely resume while the
+            # mtime is unchanged; the next successful write upgrades to hashes.
+            try:
+                unchanged = AGENT_IDENTITY_PATH.joinpath(filename).stat().st_mtime_ns == previous
+            except OSError:
+                unchanged = previous is None
+        else:
+            unchanged = previous == current.get(filename)
+        if not unchanged:
+            changed.append(filename)
+    return changed
 
 
 def _atomic_write(path, record):
@@ -499,6 +1052,64 @@ def _utcnow_iso():
     return datetime.now(timezone.utc).isoformat()
 
 
+def _session_age_seconds(record):
+    if not record or not record.get("created_at"):
+        return 0 if record is None else None
+    try:
+        created_at = datetime.fromisoformat(record["created_at"])
+        if created_at.tzinfo is None:
+            created_at = created_at.replace(tzinfo=timezone.utc)
+        return max(0, int((datetime.now(timezone.utc) - created_at).total_seconds()))
+    except (TypeError, ValueError):
+        return None
+
+
+def next_trigger_sequence(record):
+    """Increment old, missing, or malformed sidecar sequence values safely."""
+    current = _optional_int((record or {}).get("trigger_sequence"))
+    return max(0, current or 0) + 1
+
+
+def _has_additive_legacy_usage(usage):
+    return any(
+        field in usage
+        for field in (
+            "uncached_input_tokens",
+            "cache_creation_input_tokens",
+            "cache_read_input_tokens",
+            "reasoning_output_tokens",
+            "provider_request_count",
+        )
+    )
+
+
+def _timeout_stream(error, name):
+    value = getattr(error, name, None) if error else None
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return value or ""
+
+
+def _optional_int(value):
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _int_or_zero(value):
+    parsed = _optional_int(value)
+    return parsed if parsed is not None else 0
+
+
+def _byte_length(text):
+    if text is None:
+        return None
+    return len(text.encode("utf-8"))
+
+
 # ----- helpers -----
 def _tail(s: str, n: int) -> str:
     """Trim long stdout/stderr so HelixKit doesn't choke on huge payloads."""
@@ -517,7 +1128,31 @@ def build_prompt(request_text: str) -> str:
     conversation; journals are continuity context and must not look like adjacent
     transcript.
     """
-    return "\n\n".join(part for part in [identity_context(), request_text, memory_context()] if part)
+    prompt, _components = build_prompt_with_components(request_text)
+    return prompt
+
+
+def build_prompt_with_components(request_text):
+    """Build a fresh prompt and return byte sizes without retaining its contents twice."""
+    identity = identity_context()
+    journals = memory_context()
+    parts = [part for part in (identity, request_text, journals) if part]
+    prompt = "\n\n".join(parts)
+    return prompt, {
+        "identity": _byte_length(identity),
+        "request": _byte_length(request_text),
+        "journal": _byte_length(journals),
+    }
+
+
+def prompt_telemetry(full_prompt, delta_prompt, selected_prompt, mode, components):
+    return {
+        "mode": mode,
+        "full_prompt_bytes": _byte_length(full_prompt),
+        "delta_prompt_bytes": _byte_length(delta_prompt),
+        "selected_prompt_bytes": _byte_length(selected_prompt),
+        "components": components or {},
+    }
 
 
 def identity_context() -> str:

--- a/app/controllers/admin/agent_runtime_sessions_controller.rb
+++ b/app/controllers/admin/agent_runtime_sessions_controller.rb
@@ -1,0 +1,68 @@
+class Admin::AgentRuntimeSessionsController < ApplicationController
+
+  MAX_WINDOW = 31.days
+
+  skip_before_action :set_current_account
+  before_action :require_site_admin
+
+  def show
+    agent = Agent.includes(:account).find(params[:agent_id])
+    to = parse_time(params[:to]) || Time.current.utc
+    from = parse_time(params[:from]) || (to - 24.hours)
+    from = [ from, to - MAX_WINDOW ].max
+
+    report = AgentRuntimeUsageReport.new(
+      agent: agent,
+      from: from,
+      to: to,
+      filters: report_filter_params
+    ).call
+
+    render inertia: "admin/agent-runtime-sessions", props: {
+      agent: {
+        id: agent.to_param,
+        name: agent.name,
+        runtime: agent.runtime,
+        account_id: agent.account.to_param,
+        account_name: agent.account.name
+      },
+      report: report,
+      filters: report.fetch(:window).merge(report.fetch(:filters)),
+      selected_session_id: selected_session_id(report)
+    }
+  end
+
+  private
+
+  def parse_time(value)
+    Time.iso8601(value).utc if value.present?
+  rescue ArgumentError
+    nil
+  end
+
+  def report_filter_params
+    params.permit(
+      :trigger_kind,
+      :provider,
+      :model,
+      :session_outcome,
+      :session_roll_reason
+    )
+  end
+
+  def selected_session_id(report)
+    requested = params[:session_id].presence
+    return if requested.blank?
+
+    requested if report.fetch(:sessions).any? { |session| session[:session_id] == requested }
+  end
+
+  def require_site_admin
+    redirect_to root_path unless Current.user&.is_site_admin?
+  end
+
+  def current_account
+    nil
+  end
+
+end

--- a/app/controllers/admin/agent_runtime_sessions_controller.rb
+++ b/app/controllers/admin/agent_runtime_sessions_controller.rb
@@ -9,6 +9,7 @@ class Admin::AgentRuntimeSessionsController < ApplicationController
     agent = Agent.includes(:account).find(params[:agent_id])
     to = parse_time(params[:to]) || Time.current.utc
     from = parse_time(params[:from]) || (to - 24.hours)
+    from = to - 24.hours if from > to
     from = [ from, to - MAX_WINDOW ].max
 
     report = AgentRuntimeUsageReport.new(
@@ -35,8 +36,10 @@ class Admin::AgentRuntimeSessionsController < ApplicationController
   private
 
   def parse_time(value)
-    Time.iso8601(value).utc if value.present?
-  rescue ArgumentError
+    return unless value.is_a?(String) && value.present?
+
+    Time.iso8601(value).utc
+  rescue ArgumentError, TypeError
     nil
   end
 

--- a/app/controllers/agents_controller.rb
+++ b/app/controllers/agents_controller.rb
@@ -46,6 +46,7 @@ class AgentsController < ApplicationController
       local_dev_endpoint_mode: Agents::Config.publish_ports?,
       identity_export_url: identity_export_account_agent_path(current_account, @agent),
       hosting_diagnostics_url: account_agent_hosting_diagnostics_path(current_account, @agent),
+      runtime_observability_url: Current.user&.is_site_admin? ? admin_agent_runtime_path(@agent) : nil,
       sandbox_recreation_url: account_agent_sandbox_recreation_path(current_account, @agent),
       runtime_interactions: @agent.agent_runtime_interactions.recent.limit(10).map(&:as_debug_json),
       account: current_account.as_json

--- a/app/frontend/pages/admin/agent-runtime-sessions.svelte
+++ b/app/frontend/pages/admin/agent-runtime-sessions.svelte
@@ -1,0 +1,476 @@
+<script>
+  import { router } from '@inertiajs/svelte';
+  import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '$lib/components/shadcn/card';
+  import { Button } from '$lib/components/shadcn/button';
+
+  let { agent, report, filters, selected_session_id = null } = $props();
+
+  let fromValue = $state(toUtcInput(filters.from));
+  let toValue = $state(toUtcInput(filters.to));
+  let triggerKind = $state(filters.trigger_kind || '');
+  let provider = $state(filters.provider || '');
+  let model = $state(filters.model || '');
+  let sessionOutcome = $state(filters.session_outcome || '');
+  let sessionRollReason = $state(filters.session_roll_reason || '');
+
+  const tokenLabels = {
+    uncached_input_tokens: 'Ordinary input',
+    cache_creation_input_tokens: 'Cache writes',
+    cache_read_input_tokens: 'Cache reads',
+    output_tokens: 'Output',
+    reasoning_output_tokens: 'Reasoning output',
+  };
+
+  function toUtcInput(value) {
+    return value ? new Date(value).toISOString().slice(0, 16) : '';
+  }
+
+  function utcIso(value) {
+    return value ? `${value}:00Z` : undefined;
+  }
+
+  function reportParams(extra = {}) {
+    return compact({
+      from: utcIso(fromValue),
+      to: utcIso(toValue),
+      trigger_kind: triggerKind,
+      provider,
+      model,
+      session_outcome: sessionOutcome,
+      session_roll_reason: sessionRollReason,
+      ...extra,
+    });
+  }
+
+  function compact(values) {
+    return Object.fromEntries(Object.entries(values).filter(([, value]) => value !== '' && value != null));
+  }
+
+  function applyFilters(event) {
+    event.preventDefault();
+    router.get(window.location.pathname, reportParams(), { preserveState: false, preserveScroll: true });
+  }
+
+  function clearFilters() {
+    triggerKind = '';
+    provider = '';
+    model = '';
+    sessionOutcome = '';
+    sessionRollReason = '';
+    router.get(window.location.pathname, { from: utcIso(fromValue), to: utcIso(toValue) });
+  }
+
+  function selectSession(sessionId) {
+    router.get(window.location.pathname, reportParams({ session_id: sessionId }), {
+      preserveState: true,
+      preserveScroll: true,
+    });
+  }
+
+  function number(value) {
+    return value === null || value === undefined ? 'unknown' : new Intl.NumberFormat('en-US').format(value);
+  }
+
+  function aggregateNumber(value, unknownRows) {
+    if (value === null || value === undefined) return 'unknown';
+    return unknownRows > 0 ? `${number(value)} known (+ ${unknownRows} unknown)` : number(value);
+  }
+
+  function bytes(value) {
+    if (value === null || value === undefined) return 'unknown';
+    if (value < 1024) return `${value} B`;
+    if (value < 1024 * 1024) return `${(value / 1024).toFixed(1)} KiB`;
+    return `${(value / 1024 / 1024).toFixed(1)} MiB`;
+  }
+
+  function aggregateBytes(value, unknownRows) {
+    if (value === null || value === undefined) return 'unknown';
+    return unknownRows > 0 ? `${bytes(value)} known (+ ${unknownRows} unknown)` : bytes(value);
+  }
+
+  function duration(value) {
+    if (value === null || value === undefined) return 'unknown';
+    if (value < 1000) return `${value} ms`;
+    if (value < 60_000) return `${(value / 1000).toFixed(1)} s`;
+    if (value < 3_600_000) return `${(value / 60_000).toFixed(1)} min`;
+    return `${(value / 3_600_000).toFixed(1)} h`;
+  }
+
+  function timestamp(value) {
+    if (!value) return 'unknown';
+    return (
+      new Intl.DateTimeFormat('en-GB', {
+        timeZone: 'UTC',
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit',
+        hour12: false,
+      }).format(new Date(value)) + ' UTC'
+    );
+  }
+
+  function list(values) {
+    return values?.length ? values.join(', ') : 'unknown';
+  }
+
+  function booleanState(value) {
+    if (value === true) return 'yes';
+    if (value === false) return 'no';
+    return 'unknown';
+  }
+
+  function mapSummary(values) {
+    const entries = Object.entries(values || {});
+    return entries.length ? entries.map(([key, value]) => `${key}: ${value}`).join(' · ') : 'none';
+  }
+
+  function telemetryClass(state) {
+    if (state === 'complete')
+      return 'border-green-300 bg-green-50 text-green-800 dark:border-green-900 dark:bg-green-950 dark:text-green-300';
+    if (state === 'unsupported')
+      return 'border-red-300 bg-red-50 text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-300';
+    return 'border-amber-300 bg-amber-50 text-amber-800 dark:border-amber-900 dark:bg-amber-950 dark:text-amber-300';
+  }
+
+  function lifecycleClass(outcome) {
+    if (outcome === 'resumed') return 'bg-green-100 text-green-800 dark:bg-green-950 dark:text-green-300';
+    if (outcome === 'rolled' || outcome === 'fresh_fallback' || outcome === 'resume_timeout')
+      return 'bg-amber-100 text-amber-800 dark:bg-amber-950 dark:text-amber-300';
+    if (outcome === 'failed') return 'bg-red-100 text-red-800 dark:bg-red-950 dark:text-red-300';
+    return 'bg-slate-100 text-slate-800 dark:bg-slate-900 dark:text-slate-300';
+  }
+</script>
+
+<svelte:head>
+  <title>{agent.name} runtime usage</title>
+</svelte:head>
+
+<div class="container mx-auto max-w-[1800px] space-y-6 px-4 py-8">
+  <div>
+    <p class="text-sm text-muted-foreground">{agent.account_name} · {agent.runtime}</p>
+    <h1 class="text-2xl font-bold">{agent.name} runtime usage</h1>
+    <p class="mt-1 text-sm text-muted-foreground">
+      Invocation-local usage grouped by HelixKit logical session. The window and every timestamp below are UTC.
+    </p>
+  </div>
+
+  <Card>
+    <CardHeader>
+      <CardTitle>Report window and filters</CardTitle>
+      <CardDescription>
+        {report.window.from} through {report.window.to}. The reporting service only sums stored invocation fields; it
+        never reconstructs historical runtime usage.
+      </CardDescription>
+    </CardHeader>
+    <CardContent>
+      <form class="grid gap-3 md:grid-cols-2 xl:grid-cols-4" onsubmit={applyFilters}>
+        <label class="grid gap-1 text-xs text-muted-foreground">
+          From (UTC)
+          <input
+            class="rounded border bg-background px-2 py-1.5 text-sm text-foreground"
+            type="datetime-local"
+            bind:value={fromValue} />
+        </label>
+        <label class="grid gap-1 text-xs text-muted-foreground">
+          To (UTC)
+          <input
+            class="rounded border bg-background px-2 py-1.5 text-sm text-foreground"
+            type="datetime-local"
+            bind:value={toValue} />
+        </label>
+        <label class="grid gap-1 text-xs text-muted-foreground">
+          Trigger kind
+          <select class="rounded border bg-background px-2 py-1.5 text-sm text-foreground" bind:value={triggerKind}>
+            <option value="">All</option>
+            {#each report.filter_options.trigger_kind as value}<option {value}>{value}</option>{/each}
+          </select>
+        </label>
+        <label class="grid gap-1 text-xs text-muted-foreground">
+          Provider
+          <select class="rounded border bg-background px-2 py-1.5 text-sm text-foreground" bind:value={provider}>
+            <option value="">All</option>
+            {#each report.filter_options.provider as value}<option {value}>{value}</option>{/each}
+          </select>
+        </label>
+        <label class="grid gap-1 text-xs text-muted-foreground">
+          Model
+          <select class="rounded border bg-background px-2 py-1.5 text-sm text-foreground" bind:value={model}>
+            <option value="">All</option>
+            {#each report.filter_options.model as value}<option {value}>{value}</option>{/each}
+          </select>
+        </label>
+        <label class="grid gap-1 text-xs text-muted-foreground">
+          Session outcome
+          <select class="rounded border bg-background px-2 py-1.5 text-sm text-foreground" bind:value={sessionOutcome}>
+            <option value="">All</option>
+            {#each report.filter_options.session_outcome as value}<option {value}>{value}</option>{/each}
+          </select>
+        </label>
+        <label class="grid gap-1 text-xs text-muted-foreground">
+          Roll reason
+          <select
+            class="rounded border bg-background px-2 py-1.5 text-sm text-foreground"
+            bind:value={sessionRollReason}>
+            <option value="">All</option>
+            {#each report.filter_options.session_roll_reason as value}<option {value}>{value}</option>{/each}
+          </select>
+        </label>
+        <div class="flex items-end gap-2">
+          <Button type="submit" size="sm">Apply</Button>
+          <Button type="button" size="sm" variant="outline" onclick={clearFilters}>Clear dimensions</Button>
+        </div>
+      </form>
+    </CardContent>
+  </Card>
+
+  <div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-5">
+    <Card>
+      <CardHeader class="pb-2"><CardDescription>Interactions</CardDescription></CardHeader>
+      <CardContent class="text-2xl font-semibold">{number(report.summary.interactions)}</CardContent>
+    </Card>
+    <Card>
+      <CardHeader class="pb-2"><CardDescription>Logical sessions</CardDescription></CardHeader>
+      <CardContent class="text-2xl font-semibold">{number(report.summary.logical_sessions)}</CardContent>
+    </Card>
+    <Card>
+      <CardHeader class="pb-2"><CardDescription>Chaos processes</CardDescription></CardHeader>
+      <CardContent class="text-2xl font-semibold">{number(report.summary.chaos_processes)}</CardContent>
+    </Card>
+    <Card>
+      <CardHeader class="pb-2"><CardDescription>Provider requests</CardDescription></CardHeader>
+      <CardContent class="text-xl font-semibold">
+        {aggregateNumber(report.summary.provider_requests, report.summary.provider_request_unknown_rows)}
+      </CardContent>
+    </Card>
+    <Card>
+      <CardHeader class="pb-2"><CardDescription>Detailed telemetry</CardDescription></CardHeader>
+      <CardContent class="text-sm">
+        <div>{report.summary.complete_usage_rows} complete</div>
+        <div class="text-amber-700 dark:text-amber-400">
+          {report.summary.incomplete_usage_rows} incomplete · {report.summary.unavailable_usage_rows} unavailable
+        </div>
+        {#if report.summary.unsupported_usage_rows > 0}
+          <div class="text-red-700 dark:text-red-400">{report.summary.unsupported_usage_rows} unsupported</div>
+        {/if}
+      </CardContent>
+    </Card>
+  </div>
+
+  <div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-5">
+    {#each Object.entries(tokenLabels) as [key, label]}
+      <Card>
+        <CardHeader class="pb-2"><CardDescription>{label}</CardDescription></CardHeader>
+        <CardContent class="text-lg font-semibold">
+          {aggregateNumber(report.summary.tokens[key], report.summary.token_unknown_rows[key])}
+        </CardContent>
+      </Card>
+    {/each}
+  </div>
+
+  <Card>
+    <CardHeader>
+      <CardTitle>Session breakdown</CardTitle>
+      <CardDescription>
+        {report.summary.fresh} fresh · {report.summary.resumed} resumed · {report.summary.rolled} rolled ·
+        {report.summary.fallbacks} fallbacks. Selected prompts:
+        {aggregateBytes(report.summary.selected_prompt_bytes, report.summary.selected_prompt_unknown_rows)}.
+      </CardDescription>
+    </CardHeader>
+    <CardContent class="space-y-3">
+      {#if report.sessions.length === 0}
+        <p class="text-sm text-muted-foreground">
+          No runtime interactions were recorded in this UTC window and filter set.
+        </p>
+      {/if}
+
+      {#each report.sessions as session}
+        <details class="rounded border bg-muted/10" open={selected_session_id === session.session_id}>
+          <summary class="cursor-pointer list-none p-4">
+            <div class="grid gap-3 xl:grid-cols-[minmax(18rem,2fr)_repeat(6,minmax(7rem,1fr))] xl:items-center">
+              <div class="min-w-0">
+                <div class="truncate font-mono text-sm">{session.session_id}</div>
+                <div class="mt-1 text-xs text-muted-foreground">
+                  {list(session.trigger_kinds)} · {timestamp(session.first_observed_at)} → {timestamp(
+                    session.last_observed_at
+                  )}
+                </div>
+              </div>
+              <div>
+                <div class="text-xs text-muted-foreground">Duration</div>
+                {duration(session.active_duration_ms)}
+              </div>
+              <div>
+                <div class="text-xs text-muted-foreground">Interactions</div>
+                {session.interaction_count}
+              </div>
+              <div>
+                <div class="text-xs text-muted-foreground">Processes</div>
+                {session.chaos_process_count}
+              </div>
+              <div>
+                <div class="text-xs text-muted-foreground">Provider calls</div>
+                {aggregateNumber(session.provider_request_count, session.provider_request_unknown_rows)}
+              </div>
+              <div>
+                <div class="text-xs text-muted-foreground">Cache reads</div>
+                {aggregateNumber(
+                  session.tokens.cache_read_input_tokens,
+                  session.token_unknown_rows.cache_read_input_tokens
+                )}
+              </div>
+              <div>
+                <div class="text-xs text-muted-foreground">Telemetry</div>
+                <span
+                  class={`inline-flex rounded border px-2 py-0.5 text-xs ${telemetryClass(session.telemetry_state)}`}>
+                  {session.telemetry_state}
+                </span>
+              </div>
+            </div>
+          </summary>
+
+          <div class="space-y-4 border-t p-4">
+            <div class="flex flex-wrap items-center justify-between gap-3">
+              <div class="grid flex-1 gap-2 text-sm md:grid-cols-2 xl:grid-cols-4">
+                <div>
+                  <span class="text-muted-foreground">Latest outcome:</span>
+                  {session.latest_outcome || 'unknown'}
+                </div>
+                <div><span class="text-muted-foreground">Providers:</span> {list(session.providers)}</div>
+                <div><span class="text-muted-foreground">Models:</span> {list(session.models)}</div>
+                <div><span class="text-muted-foreground">Cache TTLs:</span> {list(session.cache_ttls)}</div>
+                <div><span class="text-muted-foreground">Chaos versions:</span> {list(session.chaos_versions)}</div>
+                <div><span class="text-muted-foreground">Outcomes:</span> {mapSummary(session.outcomes)}</div>
+                <div><span class="text-muted-foreground">Roll reasons:</span> {mapSummary(session.roll_reasons)}</div>
+                <div>
+                  <span class="text-muted-foreground">Selected prompts:</span>
+                  {aggregateBytes(session.selected_prompt_bytes, session.selected_prompt_unknown_rows)}
+                </div>
+              </div>
+              <Button type="button" size="sm" variant="outline" onclick={() => selectSession(session.session_id)}>
+                Permalink timeline
+              </Button>
+            </div>
+
+            {#if session.telemetry_state !== 'complete'}
+              <div class={`rounded border p-3 text-sm ${telemetryClass(session.telemetry_state)}`}>
+                Detailed invocation telemetry is not complete for every row in this session:
+                {mapSummary(session.telemetry_states)}. Values marked unknown were not reported and are not zero.
+              </div>
+            {/if}
+
+            <div class="overflow-x-auto">
+              <table class="w-full min-w-[1680px] text-left text-xs">
+                <thead class="border-b text-muted-foreground">
+                  <tr>
+                    <th class="px-2 py-2">UTC range / duration</th>
+                    <th class="px-2 py-2">Lifecycle decision</th>
+                    <th class="px-2 py-2">Chaos process transition</th>
+                    <th class="px-2 py-2">Prompt bytes</th>
+                    <th class="px-2 py-2">Runtime</th>
+                    <th class="px-2 py-2">Calls</th>
+                    <th class="px-2 py-2">Ordinary</th>
+                    <th class="px-2 py-2">Write</th>
+                    <th class="px-2 py-2">Read</th>
+                    <th class="px-2 py-2">Output</th>
+                    <th class="px-2 py-2">Reasoning</th>
+                    <th class="px-2 py-2">Telemetry</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {#each session.interactions as interaction}
+                    <tr class="border-b align-top last:border-0">
+                      <td class="px-2 py-3">
+                        <div>{timestamp(interaction.started_at)}</div>
+                        <div>{timestamp(interaction.finished_at)}</div>
+                        <div class="text-muted-foreground">{duration(interaction.duration_ms)}</div>
+                      </td>
+                      <td class="px-2 py-3">
+                        <span class={`inline-flex rounded px-2 py-0.5 ${lifecycleClass(interaction.session_outcome)}`}>
+                          {interaction.session_outcome || 'unknown'}
+                        </span>
+                        <div class="mt-1">{interaction.session_roll_reason || 'no roll reason'}</div>
+                        <div class="text-muted-foreground">
+                          persistent {booleanState(interaction.persistent_session_requested)} · mapping
+                          {booleanState(interaction.session_mapping_found)} · resume attempted
+                          {booleanState(interaction.resume_attempted)}
+                        </div>
+                        <div class="text-muted-foreground">
+                          sequence {number(interaction.session_trigger_sequence)} · age {duration(
+                            interaction.session_age_seconds == null ? null : interaction.session_age_seconds * 1000
+                          )}
+                        </div>
+                        {#if interaction.changed_identity_files?.length}
+                          <div class="text-muted-foreground">
+                            changed: {interaction.changed_identity_files.join(', ')}
+                          </div>
+                        {/if}
+                      </td>
+                      <td class="px-2 py-3 font-mono">
+                        <div>{interaction.chaos_session_id || 'unknown'}</div>
+                        {#if interaction.prior_chaos_session_id}
+                          <div class="text-muted-foreground">from {interaction.prior_chaos_session_id}</div>
+                        {:else}
+                          <div class="text-muted-foreground">prior unknown</div>
+                        {/if}
+                      </td>
+                      <td class="px-2 py-3">
+                        <div>
+                          {interaction.prompt_mode || 'unknown'} selected {bytes(interaction.selected_prompt_bytes)}
+                        </div>
+                        <div class="text-muted-foreground">full {bytes(interaction.full_prompt_bytes)}</div>
+                        <div class="text-muted-foreground">delta {bytes(interaction.delta_prompt_bytes)}</div>
+                        {#if Object.keys(interaction.prompt_component_bytes || {}).length}
+                          <div class="text-muted-foreground">
+                            {Object.entries(interaction.prompt_component_bytes)
+                              .map(([key, value]) => `${key} ${bytes(value)}`)
+                              .join(' · ')}
+                          </div>
+                        {/if}
+                      </td>
+                      <td class="px-2 py-3">
+                        <div>{interaction.provider || 'unknown'} / {interaction.model || 'unknown'}</div>
+                        <div class="text-muted-foreground">TTL {interaction.cache_ttl || 'unknown'}</div>
+                        <div class="text-muted-foreground">{interaction.chaos_version || 'Chaos version unknown'}</div>
+                        <div class="text-muted-foreground">
+                          Chaos telemetry {interaction.chaos_telemetry_status || 'unknown'}
+                          {#if interaction.unsupported_chaos_telemetry_schema_version}
+                            (schema {interaction.unsupported_chaos_telemetry_schema_version})
+                          {/if}
+                        </div>
+                        <div class="text-muted-foreground">
+                          transport {number(interaction.transport_status)} · runtime {interaction.runtime_status ||
+                            'unknown'} /
+                          {number(interaction.runtime_returncode)}
+                        </div>
+                      </td>
+                      <td class="px-2 py-3">{number(interaction.provider_request_count)}</td>
+                      <td class="px-2 py-3">{number(interaction.tokens.uncached_input_tokens)}</td>
+                      <td class="px-2 py-3">{number(interaction.tokens.cache_creation_input_tokens)}</td>
+                      <td class="px-2 py-3">{number(interaction.tokens.cache_read_input_tokens)}</td>
+                      <td class="px-2 py-3">{number(interaction.tokens.output_tokens)}</td>
+                      <td class="px-2 py-3">{number(interaction.tokens.reasoning_output_tokens)}</td>
+                      <td class="px-2 py-3">
+                        <span
+                          class={`inline-flex rounded border px-2 py-0.5 ${telemetryClass(interaction.telemetry_state)}`}>
+                          {interaction.telemetry_state}
+                        </span>
+                        <div class="mt-1 max-w-56 text-muted-foreground">{interaction.telemetry_state_reason}</div>
+                        <div class="text-muted-foreground">
+                          schema {number(interaction.telemetry_schema_version)} · scope {interaction.usage_scope ||
+                            'unknown'}
+                        </div>
+                      </td>
+                    </tr>
+                  {/each}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </details>
+      {/each}
+    </CardContent>
+  </Card>
+</div>

--- a/app/frontend/pages/agents/edit.svelte
+++ b/app/frontend/pages/agents/edit.svelte
@@ -41,6 +41,7 @@
     local_dev_endpoint_mode: localDevEndpointMode = false,
     identity_export_url: identityExportUrl = null,
     hosting_diagnostics_url: hostingDiagnosticsUrl = null,
+    runtime_observability_url: runtimeObservabilityUrl = null,
     sandbox_recreation_url: sandboxRecreationUrl = null,
     runtime_interactions: runtimeInteractions = [],
     account,
@@ -648,6 +649,11 @@
                     {#if identityExportUrl}
                       <a href={identityExportUrl}>
                         <Button type="button" variant="outline">Download identity export</Button>
+                      </a>
+                    {/if}
+                    {#if runtimeObservabilityUrl}
+                      <a href={runtimeObservabilityUrl}>
+                        <Button type="button" variant="outline">Runtime usage</Button>
                       </a>
                     {/if}
                   </div>

--- a/app/models/agent_runtime_interaction.rb
+++ b/app/models/agent_runtime_interaction.rb
@@ -33,9 +33,30 @@ class AgentRuntimeInteraction < ApplicationRecord
   end
 
   def record_result!(result)
-    body = result[:body] || {}
+    body = (result[:body] || {}).deep_dup
     full_invocation_text = body.delete("full_invocation_text")
-    usage = body["usage"] || {}
+    telemetry = body["telemetry"].presence || {}
+    runtime = telemetry["runtime"].presence || {}
+    session = telemetry["session"].presence || {}
+    prompt = telemetry["prompt"].presence || {}
+    telemetry_usage = telemetry["usage"]
+    versioned_usage = telemetry_usage.is_a?(Hash)
+    usage = versioned_usage ? telemetry_usage : body["usage"].presence || {}
+    # Only the versioned telemetry envelope promises invocation-local usage.
+    # Unversioned fields may still be process-cumulative output from an older
+    # Chaos runtime, so keep them in the compatibility columns rather than
+    # presenting them as trustworthy detailed accounting.
+    detailed_usage = versioned_usage
+    cache_read_tokens = cache_read_tokens_from(usage) if detailed_usage
+    compatible_cached_tokens = detailed_usage ? cache_read_tokens : usage["cached_input_tokens"]
+    cache_creation_tokens = usage["cache_creation_input_tokens"] if detailed_usage
+    uncached_tokens = uncached_input_tokens_from(
+      usage,
+      cache_creation_tokens: cache_creation_tokens,
+      cache_read_tokens: cache_read_tokens
+    ) if detailed_usage
+    reasoning_output_tokens = usage["reasoning_output_tokens"] if detailed_usage
+    provider_request_count = usage["provider_request_count"] if detailed_usage
 
     update!(
       transport_status: result[:status],
@@ -44,12 +65,40 @@ class AgentRuntimeInteraction < ApplicationRecord
       stdout: body["stdout"],
       stderr: body["stderr"],
       full_invocation_text: full_invocation_text,
-      chaos_session_id: body["chaos_session_id"],
-      session_resumed: body["session_resumed"],
-      fresh_fallback: body["fresh_fallback"],
+      chaos_session_id: session["chaos_process_id"] || body["chaos_session_id"],
+      session_resumed: body.key?("session_resumed") ? body["session_resumed"] : derived_session_flag(session, "resumed"),
+      fresh_fallback: body.key?("fresh_fallback") ? body["fresh_fallback"] : derived_session_flag(session, "fresh_fallback"),
+      telemetry_schema_version: telemetry["schema_version"],
+      chaos_telemetry_status: telemetry["chaos_telemetry_status"],
+      unsupported_chaos_telemetry_schema_version: telemetry["unsupported_chaos_telemetry_schema_version"],
+      chaos_version: runtime["chaos_version"],
+      provider: runtime["provider"],
+      model: runtime["model"],
+      cache_ttl: runtime["cache_ttl"],
+      persistent_session_requested: session["persistent_requested"],
+      session_mapping_found: session["mapping_found"],
+      resume_attempted: session["resume_attempted"],
+      session_outcome: session["outcome"],
+      session_roll_reason: session["roll_reason"] || body["session_roll_reason"],
+      changed_identity_files: session.key?("changed_identity_files") ? session["changed_identity_files"] : changed_identity_files,
+      prior_chaos_session_id: session["prior_chaos_process_id"],
+      session_trigger_sequence: session["trigger_sequence"],
+      session_age_seconds: session["session_age_seconds"],
+      prompt_mode: prompt["mode"],
+      full_prompt_bytes: prompt["full_prompt_bytes"],
+      delta_prompt_bytes: prompt["delta_prompt_bytes"],
+      selected_prompt_bytes: prompt["selected_prompt_bytes"],
+      prompt_component_bytes: prompt.key?("components") ? prompt["components"] : prompt_component_bytes,
+      usage_scope: usage["scope"],
       input_tokens: usage["input_tokens"],
-      cached_input_tokens: usage["cached_input_tokens"],
+      uncached_input_tokens: uncached_tokens,
+      cache_creation_input_tokens: cache_creation_tokens,
+      cache_read_input_tokens: cache_read_tokens,
+      cached_input_tokens: compatible_cached_tokens,
       output_tokens: usage["output_tokens"],
+      reasoning_output_tokens: reasoning_output_tokens,
+      provider_request_count: provider_request_count,
+      usage_complete: usage_complete_value(versioned_usage, usage),
       response_body: body,
       finished_at: Time.current,
       duration_ms: elapsed_ms
@@ -63,6 +112,41 @@ class AgentRuntimeInteraction < ApplicationRecord
       finished_at: Time.current,
       duration_ms: elapsed_ms
     )
+  end
+
+  def cache_read_ratio
+    token_ratio(cache_read_input_tokens)
+  end
+
+  def cache_creation_ratio
+    token_ratio(cache_creation_input_tokens)
+  end
+
+  def fresh_session?
+    session_outcome.in?(%w[legacy_fresh fresh])
+  end
+
+  def resumed_session?
+    session_outcome == "resumed"
+  end
+
+  def cold_start?
+    prompt_mode == "full" || fresh_session? || session_outcome.in?(%w[rolled fresh_fallback])
+  end
+
+  def provider_requests_per_trigger
+    provider_request_count
+  end
+
+  def token_breakdown
+    {
+      input: input_tokens,
+      uncached_input: uncached_input_tokens,
+      cache_creation_input: cache_creation_input_tokens,
+      cache_read_input: cache_read_input_tokens,
+      output: output_tokens,
+      reasoning_output: reasoning_output_tokens
+    }
   end
 
   def as_debug_json
@@ -83,9 +167,37 @@ class AgentRuntimeInteraction < ApplicationRecord
       chaos_session_id: chaos_session_id,
       session_resumed: session_resumed,
       fresh_fallback: fresh_fallback,
+      telemetry_schema_version: telemetry_schema_version,
+      chaos_telemetry_status: chaos_telemetry_status,
+      unsupported_chaos_telemetry_schema_version: unsupported_chaos_telemetry_schema_version,
+      chaos_version: chaos_version,
+      provider: provider,
+      model: model,
+      cache_ttl: cache_ttl,
+      persistent_session_requested: persistent_session_requested,
+      session_mapping_found: session_mapping_found,
+      resume_attempted: resume_attempted,
+      session_outcome: session_outcome,
+      session_roll_reason: session_roll_reason,
+      changed_identity_files: changed_identity_files,
+      prior_chaos_session_id: prior_chaos_session_id,
+      session_trigger_sequence: session_trigger_sequence,
+      session_age_seconds: session_age_seconds,
+      prompt_mode: prompt_mode,
+      full_prompt_bytes: full_prompt_bytes,
+      delta_prompt_bytes: delta_prompt_bytes,
+      selected_prompt_bytes: selected_prompt_bytes,
+      prompt_component_bytes: prompt_component_bytes,
+      usage_scope: usage_scope,
       input_tokens: input_tokens,
+      uncached_input_tokens: uncached_input_tokens,
+      cache_creation_input_tokens: cache_creation_input_tokens,
+      cache_read_input_tokens: cache_read_input_tokens,
       cached_input_tokens: cached_input_tokens,
       output_tokens: output_tokens,
+      reasoning_output_tokens: reasoning_output_tokens,
+      provider_request_count: provider_request_count,
+      usage_complete: usage_complete,
       started_at: started_at&.iso8601,
       finished_at: finished_at&.iso8601,
       duration_ms: duration_ms,
@@ -123,6 +235,36 @@ class AgentRuntimeInteraction < ApplicationRecord
   end
 
   private
+
+  def cache_read_tokens_from(usage)
+    return usage["cache_read_input_tokens"] if usage.key?("cache_read_input_tokens")
+
+    usage["cached_input_tokens"]
+  end
+
+  def uncached_input_tokens_from(usage, cache_creation_tokens:, cache_read_tokens:)
+    return usage["uncached_input_tokens"] unless usage["uncached_input_tokens"].nil?
+    return if usage["input_tokens"].nil? || cache_creation_tokens.nil? || cache_read_tokens.nil?
+
+    usage["input_tokens"] - cache_creation_tokens - cache_read_tokens
+  end
+
+  def token_ratio(category_tokens)
+    return if category_tokens.nil? || input_tokens.nil? || input_tokens.zero?
+
+    category_tokens.to_f / input_tokens
+  end
+
+  def usage_complete_value(versioned_usage, usage)
+    return usage["complete"] if usage.key?("complete")
+    return true if versioned_usage && usage["scope"] == "invocation"
+
+    nil
+  end
+
+  def derived_session_flag(session, outcome)
+    session["outcome"] == outcome if session.key?("outcome")
+  end
 
   def broadcast_agent_runtime_interactions_refresh
     ActionCable.server.broadcast(

--- a/app/services/agent_runtime_usage_report.rb
+++ b/app/services/agent_runtime_usage_report.rb
@@ -1,6 +1,7 @@
 class AgentRuntimeUsageReport
 
   SUPPORTED_TELEMETRY_SCHEMA_VERSION = 1
+  LOCAL_USAGE_SCOPES = %w[invocation trigger].freeze
   DETAILED_TOKEN_FIELDS = %i[
     uncached_input_tokens
     cache_creation_input_tokens
@@ -77,8 +78,8 @@ class AgentRuntimeUsageReport
       interactions: interactions.size,
       logical_sessions: interactions.map { |row| logical_session_id(row) }.uniq.size,
       chaos_processes: interactions.filter_map(&:chaos_session_id).uniq.size,
-      provider_requests: sum_invocation_usage(interactions, :provider_request_count),
-      provider_request_unknown_rows: invocation_usage_unknown_count(interactions, :provider_request_count),
+      provider_requests: sum_local_usage(interactions, :provider_request_count),
+      provider_request_unknown_rows: local_usage_unknown_count(interactions, :provider_request_count),
       fresh: interactions.count { |row| row.session_outcome == "fresh" },
       resumed: interactions.count { |row| row.session_outcome == "resumed" },
       rolled: interactions.count { |row| row.session_outcome == "rolled" },
@@ -133,8 +134,8 @@ class AgentRuntimeUsageReport
       models: interactions.filter_map(&:model).uniq,
       cache_ttls: interactions.filter_map(&:cache_ttl).uniq,
       chaos_versions: interactions.filter_map(&:chaos_version).uniq,
-      provider_request_count: sum_invocation_usage(interactions, :provider_request_count),
-      provider_request_unknown_rows: invocation_usage_unknown_count(interactions, :provider_request_count),
+      provider_request_count: sum_local_usage(interactions, :provider_request_count),
+      provider_request_unknown_rows: local_usage_unknown_count(interactions, :provider_request_count),
       selected_prompt_bytes: sum_known(interactions, :selected_prompt_bytes),
       selected_prompt_unknown_rows: unknown_count(interactions, :selected_prompt_bytes),
       tokens: token_totals(interactions),
@@ -178,13 +179,13 @@ class AgentRuntimeUsageReport
       cache_ttl: interaction.cache_ttl,
       chaos_telemetry_status: interaction.chaos_telemetry_status,
       unsupported_chaos_telemetry_schema_version: interaction.unsupported_chaos_telemetry_schema_version,
-      provider_request_count: invocation_value(interaction, :provider_request_count),
+      provider_request_count: local_usage_value(interaction, :provider_request_count),
       usage_scope: interaction.usage_scope,
       usage_complete: interaction.usage_complete,
       telemetry_schema_version: interaction.telemetry_schema_version,
       telemetry_state: state,
       telemetry_state_reason: telemetry_state_reason(interaction, state),
-      tokens: TOKEN_FIELDS.to_h { |field| [ field, invocation_value(interaction, field) ] }
+      tokens: TOKEN_FIELDS.to_h { |field| [ field, local_usage_value(interaction, field) ] }
     }
   end
 
@@ -199,11 +200,11 @@ class AgentRuntimeUsageReport
   end
 
   def token_totals(interactions)
-    TOKEN_FIELDS.to_h { |field| [ field, sum_invocation_usage(interactions, field) ] }
+    TOKEN_FIELDS.to_h { |field| [ field, sum_local_usage(interactions, field) ] }
   end
 
   def token_unknown_counts(interactions)
-    TOKEN_FIELDS.to_h { |field| [ field, invocation_usage_unknown_count(interactions, field) ] }
+    TOKEN_FIELDS.to_h { |field| [ field, local_usage_unknown_count(interactions, field) ] }
   end
 
   def grouped_counts(interactions, field)
@@ -221,26 +222,26 @@ class AgentRuntimeUsageReport
     interactions.count { |interaction| interaction.public_send(field).nil? }
   end
 
-  def sum_invocation_usage(interactions, field)
+  def sum_local_usage(interactions, field)
     values = interactions.filter_map do |interaction|
-      invocation_value(interaction, field)
+      local_usage_value(interaction, field)
     end
     values.sum if values.any?
   end
 
-  def invocation_usage_unknown_count(interactions, field)
+  def local_usage_unknown_count(interactions, field)
     interactions.count do |interaction|
-      !invocation_usage?(interaction) || interaction.public_send(field).nil?
+      !local_usage?(interaction) || interaction.public_send(field).nil?
     end
   end
 
-  def invocation_usage?(interaction)
+  def local_usage?(interaction)
     interaction.telemetry_schema_version == SUPPORTED_TELEMETRY_SCHEMA_VERSION &&
-      interaction.usage_scope == "invocation"
+      interaction.usage_scope.in?(LOCAL_USAGE_SCOPES)
   end
 
-  def invocation_value(interaction, field)
-    interaction.public_send(field) if invocation_usage?(interaction)
+  def local_usage_value(interaction, field)
+    interaction.public_send(field) if local_usage?(interaction)
   end
 
   def telemetry_state(interaction)
@@ -250,7 +251,7 @@ class AgentRuntimeUsageReport
       interaction.chaos_telemetry_status == "unsupported" ||
       interaction.unsupported_chaos_telemetry_schema_version.present?
     return "unavailable" if interaction.chaos_telemetry_status.in?(%w[missing legacy])
-    return "complete" if interaction.usage_complete == true && interaction.usage_scope == "invocation"
+    return "complete" if interaction.usage_complete == true && interaction.usage_scope.in?(LOCAL_USAGE_SCOPES)
 
     "incomplete"
   end
@@ -270,10 +271,14 @@ class AgentRuntimeUsageReport
         "runtime reported unsupported telemetry schema version #{interaction.telemetry_schema_version}"
       end
     when "complete"
-      "versioned invocation-local telemetry complete"
+      if interaction.usage_scope == "trigger"
+        "versioned trigger-local telemetry complete across multiple Chaos invocations"
+      else
+        "versioned invocation-local telemetry complete"
+      end
     when "incomplete"
-      if interaction.usage_scope.present? && interaction.usage_scope != "invocation"
-        "usage scope is #{interaction.usage_scope}, not invocation"
+      if interaction.usage_scope.present? && !interaction.usage_scope.in?(LOCAL_USAGE_SCOPES)
+        "usage scope is #{interaction.usage_scope}, not invocation or trigger"
       elsif interaction.usage_complete == false
         "runtime marked invocation telemetry incomplete"
       else

--- a/app/services/agent_runtime_usage_report.rb
+++ b/app/services/agent_runtime_usage_report.rb
@@ -1,0 +1,293 @@
+class AgentRuntimeUsageReport
+
+  SUPPORTED_TELEMETRY_SCHEMA_VERSION = 1
+  DETAILED_TOKEN_FIELDS = %i[
+    uncached_input_tokens
+    cache_creation_input_tokens
+    cache_read_input_tokens
+    output_tokens
+    reasoning_output_tokens
+  ].freeze
+  TOKEN_FIELDS = ([ :input_tokens ] + DETAILED_TOKEN_FIELDS).freeze
+  FILTER_FIELDS = %i[
+    trigger_kind
+    provider
+    model
+    session_outcome
+    session_roll_reason
+  ].freeze
+
+  attr_reader :agent, :from, :to, :filters
+
+  def initialize(agent:, from:, to:, filters: {})
+    @agent = agent
+    @from = from.utc
+    @to = to.utc
+    @filters = filters.to_h.symbolize_keys.slice(*FILTER_FIELDS).compact_blank
+
+    raise ArgumentError, "UTC report window must end at or after it starts" if @to < @from
+  end
+
+  def call
+    interactions = scope.to_a
+
+    {
+      window: {
+        from: from.iso8601,
+        to: to.iso8601,
+        timezone: "UTC"
+      },
+      filters: filters,
+      filter_options: filter_options,
+      summary: summary_for(interactions),
+      groups: groups_for(interactions),
+      sessions: interactions
+        .group_by { |interaction| logical_session_id(interaction) }
+        .map { |session_id, rows| session_json(session_id, rows) }
+        .sort_by { |session| session[:last_observed_at].to_s }
+        .reverse
+    }
+  end
+
+  private
+
+  def scope
+    relation = agent.agent_runtime_interactions
+      .includes(:chat)
+      .where(started_at: from..to)
+      .order(:started_at, :id)
+
+    filters.each do |field, value|
+      relation = relation.where(field => value)
+    end
+
+    relation
+  end
+
+  def filter_options
+    relation = agent.agent_runtime_interactions.where(started_at: from..to)
+
+    FILTER_FIELDS.to_h do |field|
+      [ field, relation.where.not(field => [ nil, "" ]).distinct.order(field).pluck(field) ]
+    end
+  end
+
+  def summary_for(interactions)
+    {
+      interactions: interactions.size,
+      logical_sessions: interactions.map { |row| logical_session_id(row) }.uniq.size,
+      chaos_processes: interactions.filter_map(&:chaos_session_id).uniq.size,
+      provider_requests: sum_invocation_usage(interactions, :provider_request_count),
+      provider_request_unknown_rows: invocation_usage_unknown_count(interactions, :provider_request_count),
+      fresh: interactions.count { |row| row.session_outcome == "fresh" },
+      resumed: interactions.count { |row| row.session_outcome == "resumed" },
+      rolled: interactions.count { |row| row.session_outcome == "rolled" },
+      fallbacks: interactions.count { |row| row.session_outcome == "fresh_fallback" || row.fresh_fallback? },
+      complete_usage_rows: interactions.count { |row| telemetry_state(row) == "complete" },
+      incomplete_usage_rows: interactions.count { |row| telemetry_state(row) == "incomplete" },
+      unavailable_usage_rows: interactions.count { |row| telemetry_state(row) == "unavailable" },
+      unsupported_usage_rows: interactions.count { |row| telemetry_state(row) == "unsupported" },
+      selected_prompt_bytes: sum_known(interactions, :selected_prompt_bytes),
+      selected_prompt_unknown_rows: unknown_count(interactions, :selected_prompt_bytes),
+      tokens: token_totals(interactions),
+      token_unknown_rows: token_unknown_counts(interactions)
+    }
+  end
+
+  def groups_for(interactions)
+    {
+      trigger_kinds: grouped_counts(interactions, :trigger_kind),
+      providers: grouped_counts(interactions, :provider),
+      models: grouped_counts(interactions, :model),
+      session_outcomes: grouped_counts(interactions, :session_outcome),
+      roll_reasons: grouped_counts(interactions, :session_roll_reason),
+      chaos_processes: grouped_counts(interactions, :chaos_session_id),
+      hours_utc: interactions
+        .group_by { |row| row.started_at&.utc&.beginning_of_hour&.iso8601 || "unknown" }
+        .transform_values(&:size)
+    }
+  end
+
+  def session_json(session_id, interactions)
+    chaos_ids = interactions.filter_map(&:chaos_session_id).uniq
+    first_started_at = interactions.filter_map(&:started_at).min
+    last_observed_at = interactions.filter_map { |row| row.finished_at || row.started_at }.max
+    telemetry_states = interactions.map { |row| telemetry_state(row) }.tally
+
+    {
+      session_id: session_id,
+      trigger_kinds: interactions.filter_map(&:trigger_kind).uniq,
+      conversation_id: interactions.filter_map(&:conversation_obfuscated_id).first,
+      chat_id: interactions.filter_map { |row| row.chat&.to_param }.first,
+      account_id: agent.account.to_param,
+      first_observed_at: first_started_at&.utc&.iso8601,
+      last_observed_at: last_observed_at&.utc&.iso8601,
+      active_duration_ms: duration_between(first_started_at, last_observed_at),
+      interaction_count: interactions.size,
+      chaos_process_ids: chaos_ids,
+      chaos_process_count: chaos_ids.size,
+      outcomes: grouped_counts(interactions, :session_outcome),
+      latest_outcome: interactions.last&.session_outcome,
+      roll_reasons: interactions.filter_map(&:session_roll_reason).tally,
+      providers: interactions.filter_map(&:provider).uniq,
+      models: interactions.filter_map(&:model).uniq,
+      cache_ttls: interactions.filter_map(&:cache_ttl).uniq,
+      chaos_versions: interactions.filter_map(&:chaos_version).uniq,
+      provider_request_count: sum_invocation_usage(interactions, :provider_request_count),
+      provider_request_unknown_rows: invocation_usage_unknown_count(interactions, :provider_request_count),
+      selected_prompt_bytes: sum_known(interactions, :selected_prompt_bytes),
+      selected_prompt_unknown_rows: unknown_count(interactions, :selected_prompt_bytes),
+      tokens: token_totals(interactions),
+      token_unknown_rows: token_unknown_counts(interactions),
+      telemetry_states: telemetry_states,
+      telemetry_state: aggregate_telemetry_state(telemetry_states),
+      interactions: interactions.map { |row| interaction_json(row) }
+    }
+  end
+
+  def interaction_json(interaction)
+    state = telemetry_state(interaction)
+
+    {
+      id: interaction.to_param,
+      trigger_kind: interaction.trigger_kind,
+      started_at: interaction.started_at&.utc&.iso8601,
+      finished_at: interaction.finished_at&.utc&.iso8601,
+      duration_ms: interaction.duration_ms,
+      transport_status: interaction.transport_status,
+      runtime_status: interaction.runtime_status,
+      runtime_returncode: interaction.runtime_returncode,
+      persistent_session_requested: interaction.persistent_session_requested,
+      session_mapping_found: interaction.session_mapping_found,
+      resume_attempted: interaction.resume_attempted,
+      session_outcome: interaction.session_outcome,
+      session_roll_reason: interaction.session_roll_reason,
+      changed_identity_files: interaction.changed_identity_files,
+      prior_chaos_session_id: interaction.prior_chaos_session_id,
+      chaos_session_id: interaction.chaos_session_id,
+      session_trigger_sequence: interaction.session_trigger_sequence,
+      session_age_seconds: interaction.session_age_seconds,
+      prompt_mode: interaction.prompt_mode,
+      full_prompt_bytes: interaction.full_prompt_bytes,
+      delta_prompt_bytes: interaction.delta_prompt_bytes,
+      selected_prompt_bytes: interaction.selected_prompt_bytes,
+      prompt_component_bytes: interaction.prompt_component_bytes,
+      chaos_version: interaction.chaos_version,
+      provider: interaction.provider,
+      model: interaction.model,
+      cache_ttl: interaction.cache_ttl,
+      chaos_telemetry_status: interaction.chaos_telemetry_status,
+      unsupported_chaos_telemetry_schema_version: interaction.unsupported_chaos_telemetry_schema_version,
+      provider_request_count: invocation_value(interaction, :provider_request_count),
+      usage_scope: interaction.usage_scope,
+      usage_complete: interaction.usage_complete,
+      telemetry_schema_version: interaction.telemetry_schema_version,
+      telemetry_state: state,
+      telemetry_state_reason: telemetry_state_reason(interaction, state),
+      tokens: TOKEN_FIELDS.to_h { |field| [ field, invocation_value(interaction, field) ] }
+    }
+  end
+
+  def logical_session_id(interaction)
+    interaction.session_id.presence || "interaction-#{interaction.id}"
+  end
+
+  def duration_between(started_at, finished_at)
+    return if started_at.blank? || finished_at.blank?
+
+    ((finished_at - started_at) * 1000).round
+  end
+
+  def token_totals(interactions)
+    TOKEN_FIELDS.to_h { |field| [ field, sum_invocation_usage(interactions, field) ] }
+  end
+
+  def token_unknown_counts(interactions)
+    TOKEN_FIELDS.to_h { |field| [ field, invocation_usage_unknown_count(interactions, field) ] }
+  end
+
+  def grouped_counts(interactions, field)
+    interactions
+      .group_by { |row| row.public_send(field).presence || "unknown" }
+      .transform_values(&:size)
+  end
+
+  def sum_known(interactions, field)
+    values = interactions.filter_map { |interaction| interaction.public_send(field) }
+    values.sum if values.any?
+  end
+
+  def unknown_count(interactions, field)
+    interactions.count { |interaction| interaction.public_send(field).nil? }
+  end
+
+  def sum_invocation_usage(interactions, field)
+    values = interactions.filter_map do |interaction|
+      invocation_value(interaction, field)
+    end
+    values.sum if values.any?
+  end
+
+  def invocation_usage_unknown_count(interactions, field)
+    interactions.count do |interaction|
+      !invocation_usage?(interaction) || interaction.public_send(field).nil?
+    end
+  end
+
+  def invocation_usage?(interaction)
+    interaction.telemetry_schema_version == SUPPORTED_TELEMETRY_SCHEMA_VERSION &&
+      interaction.usage_scope == "invocation"
+  end
+
+  def invocation_value(interaction, field)
+    interaction.public_send(field) if invocation_usage?(interaction)
+  end
+
+  def telemetry_state(interaction)
+    version = interaction.telemetry_schema_version
+    return "unavailable" if version.nil?
+    return "unsupported" if version > SUPPORTED_TELEMETRY_SCHEMA_VERSION ||
+      interaction.chaos_telemetry_status == "unsupported" ||
+      interaction.unsupported_chaos_telemetry_schema_version.present?
+    return "unavailable" if interaction.chaos_telemetry_status.in?(%w[missing legacy])
+    return "complete" if interaction.usage_complete == true && interaction.usage_scope == "invocation"
+
+    "incomplete"
+  end
+
+  def telemetry_state_reason(interaction, state)
+    case state
+    when "unavailable"
+      if interaction.chaos_telemetry_status == "legacy"
+        "Chaos runtime reported only legacy cumulative usage"
+      else
+        "runtime image did not report versioned invocation telemetry"
+      end
+    when "unsupported"
+      if interaction.unsupported_chaos_telemetry_schema_version.present?
+        "Chaos runtime reported unsupported telemetry schema version #{interaction.unsupported_chaos_telemetry_schema_version}"
+      else
+        "runtime reported unsupported telemetry schema version #{interaction.telemetry_schema_version}"
+      end
+    when "complete"
+      "versioned invocation-local telemetry complete"
+    when "incomplete"
+      if interaction.usage_scope.present? && interaction.usage_scope != "invocation"
+        "usage scope is #{interaction.usage_scope}, not invocation"
+      elsif interaction.usage_complete == false
+        "runtime marked invocation telemetry incomplete"
+      else
+        "runtime did not confirm complete invocation telemetry"
+      end
+    end
+  end
+
+  def aggregate_telemetry_state(states)
+    return "unsupported" if states["unsupported"].to_i.positive?
+    return "unavailable" if states["unavailable"].to_i.positive?
+    return "incomplete" if states["incomplete"].to_i.positive?
+
+    "complete"
+  end
+
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -125,6 +125,9 @@ Rails.application.routes.draw do
   end
 
   namespace :admin do
+    resources :agents, only: [] do
+      resource :runtime, only: :show, controller: "agent_runtime_sessions"
+    end
     resources :accounts, only: [ :index ] do
       member do
         patch :disable

--- a/db/migrate/20260718152000_add_observability_to_agent_runtime_interactions.rb
+++ b/db/migrate/20260718152000_add_observability_to_agent_runtime_interactions.rb
@@ -1,0 +1,48 @@
+class AddObservabilityToAgentRuntimeInteractions < ActiveRecord::Migration[8.0]
+
+  def change
+    change_table :agent_runtime_interactions, bulk: true do |t|
+      t.integer :telemetry_schema_version
+      t.string :chaos_telemetry_status
+      t.integer :unsupported_chaos_telemetry_schema_version
+      t.string :chaos_version
+      t.string :provider
+      t.string :model
+      t.string :cache_ttl
+
+      t.boolean :persistent_session_requested
+      t.boolean :session_mapping_found
+      t.boolean :resume_attempted
+      t.string :session_outcome
+      t.string :session_roll_reason
+      t.jsonb :changed_identity_files, default: []
+      t.string :prior_chaos_session_id
+      t.integer :session_trigger_sequence
+      t.integer :session_age_seconds
+
+      t.string :prompt_mode
+      t.bigint :full_prompt_bytes
+      t.bigint :delta_prompt_bytes
+      t.bigint :selected_prompt_bytes
+      t.jsonb :prompt_component_bytes, default: {}
+
+      t.string :usage_scope
+      t.bigint :uncached_input_tokens
+      t.bigint :cache_creation_input_tokens
+      t.bigint :cache_read_input_tokens
+      t.bigint :reasoning_output_tokens
+      t.integer :provider_request_count
+      t.boolean :usage_complete
+    end
+
+    add_index :agent_runtime_interactions, [ :agent_id, :session_id, :started_at ],
+      name: "idx_runtime_interactions_agent_session_started"
+    add_index :agent_runtime_interactions, [ :agent_id, :chaos_session_id, :started_at ],
+      name: "idx_runtime_interactions_agent_chaos_started"
+    add_index :agent_runtime_interactions, [ :agent_id, :session_outcome, :started_at ],
+      name: "idx_runtime_interactions_agent_outcome_started"
+    add_index :agent_runtime_interactions, [ :agent_id, :session_roll_reason, :started_at ],
+      name: "idx_runtime_interactions_agent_roll_reason_started"
+  end
+
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_18_103000) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_18_152000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -154,11 +154,18 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_18_103000) do
 
   create_table "agent_runtime_interactions", force: :cascade do |t|
     t.bigint "agent_id", null: false
+    t.bigint "cache_creation_input_tokens"
+    t.bigint "cache_read_input_tokens"
+    t.string "cache_ttl"
     t.bigint "cached_input_tokens"
+    t.jsonb "changed_identity_files", default: []
     t.string "chaos_session_id"
+    t.string "chaos_telemetry_status"
+    t.string "chaos_version"
     t.bigint "chat_id"
     t.string "conversation_obfuscated_id"
     t.datetime "created_at", null: false
+    t.bigint "delta_prompt_bytes"
     t.integer "duration_ms"
     t.string "endpoint_url"
     t.string "error_class"
@@ -166,23 +173,48 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_18_103000) do
     t.datetime "finished_at"
     t.boolean "fresh_fallback"
     t.text "full_invocation_text"
+    t.bigint "full_prompt_bytes"
     t.bigint "input_tokens"
     t.bigint "last_included_message_id"
+    t.string "model"
     t.bigint "output_tokens"
+    t.boolean "persistent_session_requested"
+    t.string "prior_chaos_session_id"
+    t.jsonb "prompt_component_bytes", default: {}
+    t.string "prompt_mode"
+    t.string "provider"
+    t.integer "provider_request_count"
+    t.bigint "reasoning_output_tokens"
     t.text "request_text"
     t.string "requested_by"
     t.jsonb "response_body", default: {}, null: false
+    t.boolean "resume_attempted"
     t.integer "runtime_returncode"
     t.string "runtime_status"
+    t.bigint "selected_prompt_bytes"
+    t.integer "session_age_seconds"
     t.string "session_id"
+    t.boolean "session_mapping_found"
+    t.string "session_outcome"
     t.boolean "session_resumed"
+    t.string "session_roll_reason"
+    t.integer "session_trigger_sequence"
     t.datetime "started_at", null: false
     t.text "stderr"
     t.text "stdout"
+    t.integer "telemetry_schema_version"
     t.integer "transport_status"
     t.string "trigger_kind", null: false
+    t.bigint "uncached_input_tokens"
+    t.integer "unsupported_chaos_telemetry_schema_version"
     t.datetime "updated_at", null: false
+    t.boolean "usage_complete"
+    t.string "usage_scope"
+    t.index ["agent_id", "chaos_session_id", "started_at"], name: "idx_runtime_interactions_agent_chaos_started"
     t.index ["agent_id", "created_at"], name: "index_agent_runtime_interactions_on_agent_id_and_created_at"
+    t.index ["agent_id", "session_id", "started_at"], name: "idx_runtime_interactions_agent_session_started"
+    t.index ["agent_id", "session_outcome", "started_at"], name: "idx_runtime_interactions_agent_outcome_started"
+    t.index ["agent_id", "session_roll_reason", "started_at"], name: "idx_runtime_interactions_agent_roll_reason_started"
     t.index ["agent_id"], name: "index_agent_runtime_interactions_on_agent_id"
     t.index ["chat_id", "created_at"], name: "index_agent_runtime_interactions_on_chat_id_and_created_at"
     t.index ["chat_id"], name: "index_agent_runtime_interactions_on_chat_id"

--- a/docs/requirements/20260718-hosted-agent-runtime-observability-implementation-plan.md
+++ b/docs/requirements/20260718-hosted-agent-runtime-observability-implementation-plan.md
@@ -1,0 +1,1077 @@
+# Hosted-agent runtime observability — forward-only implementation plan
+
+Date: 2026-07-18
+
+Status: implemented on 2026-07-18; deployment verification remains
+
+Implementation note: Phases 0–3 are represented by deterministic Chaos contract
+tests, forward-only HelixKit capture/persistence, and the administrator session
+timeline. Historical recovery and optional per-provider-request event storage
+remain deliberately out of scope. Production verification must use the normal
+image/Kamal path and a disposable agent.
+
+Related:
+
+- `docs/requirements/20260718-hosted-agent-runtime-observability.md`
+- `agent-runtime/trigger_shim.py`
+- `test/lib/trigger_shim_session_test.rb`
+- Chaos `sys/exec/fork/src/event_processor_with_jsonl_output.rs`
+- Chaos `lib/libcontract/ipc/src/protocol/events_token.rs`
+- Chaos `sys/kern/providers/parrot/src/anthropic.rs`
+
+## Purpose
+
+Build trustworthy, forward-looking observability for hosted-agent sessions.
+
+The implementation has three separate responsibilities:
+
+1. **Chaos reports accurate usage and lifecycle facts about one invocation.**
+2. **HelixKit records those facts against the interaction and session that caused
+   them.**
+3. **HelixKit displays session summaries and interaction timelines that explain
+   where tokens are going.**
+
+There is a short Chaos-characterisation step before those implementation phases.
+Its purpose is to turn assumptions about current Chaos behaviour into executable
+tests.
+
+This plan does not attempt to reconstruct historical usage.
+
+## Explicit scope decisions
+
+### Forward-only accounting
+
+Detailed observability begins when the instrumented Chaos runtime and HelixKit
+consumer are deployed.
+
+Do not:
+
+- backfill new token categories on old interaction rows;
+- query or replay old Chaos session history to manufacture missing usage;
+- recover usage that occurred before an already-running session first reports
+  the new contract;
+- infer cache creation from old blended token totals;
+- assign zero to a field that was not reported.
+
+Historical and old-runtime rows may continue to show the existing coarse fields.
+New fields should display as `unknown` when they were not reported.
+
+### Prefer invocation-local usage
+
+The primary accounting object is one HelixKit runtime interaction: one request
+to the hosted runtime and the complete Chaos invocation it causes.
+
+Chaos should report usage for that invocation directly. HelixKit should not have
+to reconstruct it by subtracting process-lifetime counters stored in a sidecar.
+
+An invocation includes:
+
+- the initial provider request;
+- provider continuations after tool calls;
+- a Stop-hook continuation, if one occurs before the invocation completes;
+- any other provider request made as part of the same `chaos exec`.
+
+Chaos may additionally report process/session cumulative totals, but they must
+be separately named and must not be confused with invocation-local usage.
+
+### Tokens, not authoritative dollars
+
+Persist token categories and lifecycle facts. Do not make estimated cost the
+source of truth in the first implementation.
+
+The UI may later estimate cost from a versioned model-pricing table, but the
+observability contract should remain correct when prices or model aliases
+change.
+
+### No raw prompt expansion
+
+Record prompt sizes and lifecycle metadata, not additional copies of prompt,
+identity, journal, transcript, or tool-output contents.
+
+Existing debug fields can remain under their existing authorization boundary.
+The new diagnostics screen should be administrator-only initially.
+
+---
+
+## The three objects that must remain distinct
+
+### HelixKit interaction
+
+One Rails request to the external runtime, stored as
+`AgentRuntimeInteraction`.
+
+This is the unit against which invocation-local usage is recorded.
+
+### Logical agent session
+
+The HelixKit `session_id`, such as a conversation, Telegram thread, or wake
+session. It may span multiple runtime interactions.
+
+This is the main grouping used by the session summary screen.
+
+### Chaos process
+
+The Chaos `process_id` used for fresh execution and resume. A logical HelixKit
+session may use more than one Chaos process because of model changes, identity
+changes, failed resumes, deployment, or deliberate rolling.
+
+A single Chaos process may receive many HelixKit interactions.
+
+### Provider request
+
+One request dispatched by Chaos to Anthropic or another model provider.
+
+There may be several provider requests in one Chaos invocation because of tools
+or lifecycle hooks. `provider_request_count` therefore cannot be inferred from
+HelixKit interaction count.
+
+---
+
+## Canonical forward contract
+
+The final shim response should carry a versioned telemetry object:
+
+```json
+{
+  "telemetry": {
+    "schema_version": 1,
+    "runtime": {
+      "chaos_version": "chaos 0.1.0 (abcdef1)",
+      "provider": "anthropic",
+      "model": "claude-fable-5",
+      "cache_ttl": "1h"
+    },
+    "session": {
+      "logical_session_id": "<agent-uuid>-519",
+      "persistent_requested": true,
+      "mapping_found": true,
+      "resume_attempted": true,
+      "outcome": "resumed",
+      "roll_reason": null,
+      "changed_identity_files": [],
+      "prior_chaos_process_id": "019f...",
+      "chaos_process_id": "019f...",
+      "trigger_sequence": 5,
+      "session_age_seconds": 522
+    },
+    "prompt": {
+      "mode": "delta",
+      "full_prompt_bytes": 92338,
+      "delta_prompt_bytes": 3145,
+      "selected_prompt_bytes": 3145,
+      "components": {}
+    },
+    "usage": {
+      "scope": "invocation",
+      "input_tokens": 171220,
+      "uncached_input_tokens": 1420,
+      "cache_creation_input_tokens": 3800,
+      "cache_read_input_tokens": 166000,
+      "output_tokens": 620,
+      "reasoning_output_tokens": null,
+      "provider_request_count": 3
+    }
+  }
+}
+```
+
+Token arithmetic, when every input category is reported:
+
+```text
+input_tokens =
+  uncached_input_tokens
+  + cache_creation_input_tokens
+  + cache_read_input_tokens
+```
+
+`NULL` means not reported or not available. Zero means the runtime/provider
+reported none.
+
+The existing top-level fields can remain temporarily for compatibility, but the
+new recording and diagnostics code should use the versioned telemetry object.
+
+---
+
+## Phase 0 — Characterise the current Chaos harness
+
+### Goal
+
+Establish exactly what Chaos currently reports, at which event boundary, and
+whether each value is provider-request-local, turn-local, or process-cumulative.
+
+This phase should produce tests and a short finding, not production telemetry.
+
+### Questions to answer
+
+1. What `TokenCount` events are emitted during one simple model response?
+2. Does `turn.completed.usage` currently contain:
+   - the latest provider request;
+   - the current turn/invocation;
+   - or the entire resumed process lifetime?
+3. When one turn invokes a tool and calls the provider again, are both provider
+   requests included in the final total?
+4. Is the Stop-hook continuation included before `turn.completed`?
+5. On `chaos exec resume`, does the emitted usage begin at zero for the new
+   invocation or include previous turns?
+6. Does Anthropic usage preserve these provider categories internally:
+   - ordinary input;
+   - cache creation;
+   - cache read;
+   - output?
+7. At what layer is `cache_creation_input_tokens` currently collapsed?
+
+### Tests
+
+Add narrowly focused tests rather than a broad integration suite.
+
+#### A. Event-processor fixture test
+
+Location:
+
+- `sys/exec/fork/tests/suite/event_processor_with_json_output.rs`
+
+Feed the JSON event processor a deterministic sequence:
+
+1. `SessionConfigured`
+2. `TurnStarted`
+3. a first `TokenCount` with known totals
+4. a tool begin/end pair
+5. a second `TokenCount` with larger known totals
+6. `TurnComplete`
+
+Assert the exact `turn.completed` JSON usage emitted at the end.
+
+This establishes what the JSONL boundary does independently of a real provider.
+
+#### B. Token accumulation test
+
+Location:
+
+- `lib/libcontract/ipc/src/protocol/events_token.rs`
+- the existing session/token tests around `TokenUsageInfo`
+
+Construct two provider-usage values and assert:
+
+- `last_token_usage` is the second value;
+- `total_token_usage` is their element-wise sum;
+- cache read and cache creation remain distinct after the Phase 1 change;
+- context-window totals are not accidentally used as billed prompt totals.
+
+#### C. Resume harness test
+
+Use a disposable Chaos process and deterministic/fake provider:
+
+1. execute a first turn;
+2. capture its process ID and final JSONL;
+3. resume the same process for a second turn;
+4. capture the second JSONL;
+5. assert the documented scope of every usage object.
+
+The test should make the distinction explicit. For example:
+
+```text
+first invocation usage:  input=100, output=10
+second invocation usage: input=140, output=12
+session cumulative:      input=240, output=22
+```
+
+Do not leave a test whose correctness depends on knowing that an ambiguously
+named `usage` field happens to be cumulative.
+
+#### D. Anthropic adapter test
+
+Feed a recorded/synthetic Anthropic SSE usage sequence containing:
+
+```text
+input_tokens
+cache_creation_input_tokens
+cache_read_input_tokens
+output_tokens
+```
+
+Assert all four survive the adapter mapping.
+
+No live provider call is required for the deterministic test.
+
+#### E. Optional one-call smoke test
+
+After deterministic tests pass, run one explicitly opt-in test against a
+non-production Anthropic account/model:
+
+- one short prompt;
+- no tools;
+- cache enabled;
+- save the raw JSONL as a local test artifact;
+- assert categories and scope, not exact token counts.
+
+This is a sanity check, not part of the normal test suite.
+
+### Deliverable
+
+A brief checked-in note or test comment stating:
+
+- current behaviour;
+- desired behaviour;
+- the exact contract Phase 1 will expose.
+
+### Exit criterion
+
+We can explain, from tests, what each current counter means and why the proposed
+invocation-local contract is correct.
+
+---
+
+## Phase 1 — Chaos instrumentation
+
+### Goal
+
+Make Chaos emit an accurate, unambiguous usage summary for one invocation.
+
+### 1. Preserve all provider token categories
+
+Extend canonical `TokenUsage` to preserve:
+
+```text
+input_tokens
+cache_creation_input_tokens
+cached_input_tokens / cache_read_input_tokens
+output_tokens
+reasoning_output_tokens
+```
+
+Keep `cached_input_tokens` as a compatibility alias if needed, but document that
+it means cache-read input. New JSON should use `cache_read_input_tokens`.
+
+Update:
+
+- Anthropic adapter mapping;
+- `TokenUsage::add_assign`;
+- defaults and constructors;
+- ABI/IPC serialization;
+- TypeScript/schema snapshots;
+- display helpers that currently calculate “non-cached” input.
+
+The existing helper:
+
+```text
+input_tokens - cached_input_tokens
+```
+
+will still blend ordinary input and cache creation. Rename or document that
+helper rather than presenting it as ordinary uncached input.
+
+### 2. Count provider requests
+
+Increment `provider_request_count` at the point Chaos dispatches an actual
+provider request.
+
+Do not increment it for:
+
+- a HelixKit trigger;
+- `chaos exec`;
+- a tool call itself;
+- an item/event emitted to JSONL;
+- a resume operation that makes no provider request.
+
+The final count must include all provider requests completed within the
+invocation, including tool continuations and the Stop hook.
+
+### 3. Emit invocation-local usage
+
+At invocation start, capture the process cumulative usage baseline and provider
+request baseline. At invocation completion, subtract the baseline and emit the
+delta as an explicitly scoped object.
+
+Preferred JSONL shape:
+
+```json
+{
+  "type": "turn.completed",
+  "telemetry_schema_version": 1,
+  "usage": {
+    "scope": "invocation",
+    "input_tokens": 171220,
+    "uncached_input_tokens": 1420,
+    "cache_creation_input_tokens": 3800,
+    "cache_read_input_tokens": 166000,
+    "output_tokens": 620,
+    "reasoning_output_tokens": null,
+    "provider_request_count": 3
+  },
+  "session_usage": {
+    "scope": "process_cumulative",
+    "input_tokens": 804276,
+    "cache_creation_input_tokens": 12140,
+    "cache_read_input_tokens": 778556,
+    "output_tokens": 10108,
+    "provider_request_count": 15
+  }
+}
+```
+
+`session_usage` is optional. The load-bearing requirement is the
+invocation-local `usage`.
+
+This design means a newly deployed HelixKit consumer can record the next
+invocation accurately even if the Chaos process began before observability was
+deployed. It does not need to reconstruct the earlier usage.
+
+### 4. Define completion boundaries
+
+`turn.completed` must be emitted only after every provider request that belongs
+to the invocation has completed.
+
+If the Stop hook runs as part of the same `chaos exec`, its usage belongs in the
+invocation aggregate.
+
+If Chaos cannot currently guarantee that ordering, add a distinct
+`invocation.completed` event rather than overloading an earlier turn-completion
+event.
+
+### 5. Failure semantics
+
+For a failed invocation:
+
+- emit usage accumulated before failure if Chaos has it;
+- mark the event/status as incomplete;
+- never report a successful complete aggregate when requests may still be
+  running;
+- do not fabricate missing provider categories.
+
+Timeouts imposed by the outer HelixKit shim may still prevent a final Chaos event
+from being received. Forward observability should make those rows visibly
+incomplete; historical recovery is out of scope.
+
+### Phase 1 tests
+
+#### Token contract
+
+1. Anthropic mapping preserves ordinary input, cache creation, cache read, and
+   output.
+2. `TokenUsage::add_assign` sums every category.
+3. Serialization emits the new fields.
+4. Missing provider categories remain unknown where the contract permits
+   unknown values.
+5. Arithmetic invariants are checked when all categories are available.
+
+#### Invocation scope
+
+1. One provider request produces `provider_request_count = 1`.
+2. A tool-using turn with three provider dispatches produces count 3.
+3. A Stop-hook continuation is included in the same invocation aggregate.
+4. A second invocation on a resumed process reports only the second invocation
+   in `usage`.
+5. Optional `session_usage` equals the sum of both invocations.
+6. A failed provider request is counted according to a documented rule and its
+   available usage is retained.
+
+#### JSONL contract
+
+1. `turn.completed` or `invocation.completed` carries
+   `telemetry_schema_version`.
+2. `usage.scope` is exactly `invocation`.
+3. `session_usage.scope`, if present, is exactly `process_cumulative`.
+4. Existing unrelated JSONL event shapes remain unchanged.
+
+### Phase 1 exit criteria
+
+- No subtraction in HelixKit is needed to determine usage for a new
+  interaction.
+- Cache creation and cache read are separately visible.
+- Provider request count is accurate.
+- Resume behaviour is covered by a deterministic test.
+- The event completion boundary is documented and tested.
+
+---
+
+## Phase 2 — HelixKit capture and persistence
+
+### Goal
+
+Capture the Chaos contract, add shim-owned lifecycle information, and persist one
+complete forward-looking interaction record.
+
+### 1. Parse versioned Chaos telemetry in the shim
+
+Update `agent-runtime/trigger_shim.py` to:
+
+- parse `telemetry_schema_version`;
+- prefer invocation-local usage;
+- preserve unknown fields as `None`;
+- include the effective Chaos version/commit;
+- reject or clearly mark an unsupported future schema;
+- pass through optional process-cumulative usage only for diagnostics.
+
+Do not use `usage_since()` for the new invocation-local contract.
+
+The old cumulative subtraction can remain temporarily for old runtime output,
+but it is not part of the new observability design and should not populate the
+new detailed fields.
+
+### 2. Add shim-owned session lifecycle telemetry
+
+The shim already knows facts Chaos does not:
+
+- logical HelixKit session ID;
+- whether persistence was requested;
+- whether a sidecar mapping existed;
+- whether resume was attempted;
+- whether the invocation ran fresh or resumed;
+- why it rolled;
+- previous and resulting Chaos process IDs;
+- full/delta prompt availability and selected mode;
+- prompt byte sizes;
+- identity fingerprint comparison;
+- trigger sequence and session age.
+
+Record those decisions as they happen rather than reconstructing them from the
+final response.
+
+Suggested outcomes:
+
+```text
+fresh
+resumed
+rolled
+fresh_fallback
+resume_timeout
+already_running
+failed
+```
+
+Suggested roll reasons:
+
+```text
+provider-changed
+model-changed
+identity-changed
+resume-failed
+sidecar-schema-unsupported
+runtime-upgrade
+```
+
+### 3. Use content hashes for identity decisions
+
+Replace mtime equality with content fingerprints:
+
+```json
+{
+  "self-narrative.md": {
+    "sha256": "...",
+    "bytes": 28114
+  }
+}
+```
+
+An unchanged file touch or deployment rewrite must not roll the session.
+
+A real byte change should record:
+
+```json
+{
+  "roll_reason": "identity-changed",
+  "changed_identity_files": ["self-narrative.md"]
+}
+```
+
+This is a correctness improvement for future sessions, not historical
+reconstruction.
+
+### 4. Record prompt sizes
+
+For every invocation:
+
+```text
+full_prompt_bytes
+delta_prompt_bytes
+selected_prompt_bytes
+prompt_mode: full | delta
+```
+
+For fresh invocations, optionally record component byte sizes:
+
+```text
+identity
+request/transcript
+journal
+other scaffolding
+```
+
+Do not store new copies of the component contents.
+
+### 5. Persist additive fields
+
+Add columns to `agent_runtime_interactions` for:
+
+#### Runtime
+
+```text
+telemetry_schema_version
+chaos_version
+provider
+model
+cache_ttl
+```
+
+#### Session lifecycle
+
+```text
+persistent_session_requested
+session_mapping_found
+resume_attempted
+session_outcome
+session_roll_reason
+changed_identity_files
+prior_chaos_session_id
+chaos_session_id
+session_trigger_sequence
+session_age_seconds
+```
+
+#### Prompt
+
+```text
+prompt_mode
+full_prompt_bytes
+delta_prompt_bytes
+selected_prompt_bytes
+prompt_component_bytes
+```
+
+#### Invocation usage
+
+```text
+uncached_input_tokens
+cache_creation_input_tokens
+cache_read_input_tokens
+input_tokens
+output_tokens
+reasoning_output_tokens
+provider_request_count
+usage_complete
+```
+
+Keep current coarse columns during migration. Do not backfill the new columns.
+
+Use `bigint` for token counters and JSONB only for naturally structured,
+low-volume fields such as changed filenames and prompt components.
+
+### 6. Record trigger/channel dimensions
+
+The diagnostics must distinguish at least:
+
+```text
+conversation
+wake
+telegram
+memory aggregation
+orientation/other
+```
+
+Reuse `trigger_kind` where it is already reliable. Add a separate channel only
+if `trigger_kind` cannot distinguish conversation and Telegram activity.
+
+### 7. Handle deployment transition honestly
+
+When HelixKit receives:
+
+- an old shim response;
+- an old Chaos event;
+- an unsupported telemetry version;
+- or an incomplete timeout/failure;
+
+it should still record the interaction, but the detailed fields should remain
+unknown and the UI should explain why.
+
+Do not attempt to initialise detailed counters by reading an existing Chaos
+process's historical total.
+
+### Phase 2 tests
+
+#### Shim parsing
+
+1. Parse all invocation-local categories from a version-1 Chaos event.
+2. Keep zero distinct from missing.
+3. Ignore process-cumulative usage for interaction billing.
+4. Preserve it as optional diagnostics if desired.
+5. Parse multiple JSONL events and select the final invocation-completion event.
+6. Record fresh and resumed lifecycle decisions.
+7. Record model/provider/identity roll reasons.
+8. Same-content identity touch does not roll.
+9. Real identity bytes change and name the file.
+10. Prompt byte sizes and selected mode are exact.
+11. Unsupported telemetry versions are recorded as unsupported, not silently
+    misparsed.
+
+#### Rails model/persistence
+
+1. Migration types and defaults are correct.
+2. `record_result!` persists all runtime, session, prompt, and usage fields.
+3. Old response shapes continue to create an interaction without detailed
+   telemetry.
+4. Unknown remains `NULL`.
+5. Zero remains zero.
+6. `usage_complete` is false for incomplete/failure output.
+7. Raw diagnostics are not added to ordinary chat activity JSON.
+
+#### Boundary contract
+
+Create a fixture JSONL document matching the Chaos test output and use the same
+fixture in the shim parser test. This prevents the producer and consumer tests
+from independently agreeing with themselves while disagreeing with each other.
+
+### Phase 2 exit criteria
+
+- Every new instrumented interaction records an invocation-local token
+  breakdown.
+- Every interaction explains fresh/resume/roll/fallback.
+- Same-content identity rewrites no longer cause false rolls.
+- Old or incomplete output remains recordable without pretending it contains
+  detailed telemetry.
+
+---
+
+## Phase 3 — HelixKit session diagnostics UI
+
+### Goal
+
+Provide an administrator screen that makes token usage and session lifecycle
+understandable without Rails console work.
+
+### Route and access
+
+Add an admin-only agent runtime diagnostics route, for example:
+
+```text
+/accounts/:account_id/agents/:agent_id/runtime
+```
+
+Authorisation should match or exceed the existing boundary protecting runtime
+stdout, stderr, invocation text, and response bodies.
+
+The default page should not render raw prompts, identity contents, transcripts,
+or tool output.
+
+### Screen 1 — Session summary
+
+Group primarily by HelixKit logical `session_id`.
+
+Each row should show:
+
+- session/channel label and linked chat/thread where available;
+- trigger kind;
+- first and last observed time;
+- active duration;
+- number of HelixKit interactions;
+- number of Chaos processes used;
+- fresh/resumed/rolled/fallback counts;
+- latest session outcome;
+- roll reasons;
+- provider and model;
+- cache TTL;
+- provider request count;
+- ordinary input;
+- cache creation;
+- cache read;
+- output;
+- total selected prompt bytes;
+- telemetry completeness.
+
+Suggested summary cards for the selected UTC window:
+
+```text
+Interactions
+Logical sessions
+Chaos processes
+Provider requests
+Fresh / resumed / rolled
+Ordinary input
+Cache writes
+Cache reads
+Output
+Rows with incomplete telemetry
+```
+
+Do not combine token categories into a single “input” number without also
+showing the category breakdown.
+
+### Screen 2 — Session detail/timeline
+
+Clicking a logical session should show interactions in chronological order:
+
+```text
+15:14 fresh   model-changed     process A  full   90 KB
+15:20 rolled  identity-changed  process B  full   92 KB
+15:22 resumed                   process B  delta   3 KB
+15:24 resumed                   process B  delta   4 KB
+```
+
+For every interaction show:
+
+- exact UTC start/end;
+- duration;
+- fresh/resume/roll/fallback badge;
+- prior and resulting Chaos process;
+- prompt mode and sizes;
+- provider/model/cache TTL;
+- provider request count;
+- uncached input;
+- cache creation;
+- cache read;
+- output;
+- whether usage is complete;
+- link to the associated chat/runtime interaction where authorised.
+
+This timeline is the primary diagnostic. Automatic alarms should wait until real
+baseline data exists.
+
+### Screen 3 — Chaos-process grouping
+
+The session detail should allow grouping or filtering by Chaos process ID.
+
+This answers:
+
+- how many HelixKit interactions reused this process;
+- how its per-invocation cache reads changed as the context grew;
+- when and why HelixKit moved to another process;
+- whether one logical session is unexpectedly churning processes.
+
+### Filters
+
+At minimum:
+
+- UTC time range;
+- agent;
+- trigger kind/channel;
+- provider;
+- model;
+- session outcome;
+- roll reason;
+- complete/incomplete telemetry.
+
+Default to a small recent window, such as 24 hours, so the page remains cheap.
+
+### Summary service
+
+Add a query/service object, for example:
+
+```ruby
+AgentRuntimeUsageReport.new(
+  agent: agent,
+  from: ...,
+  to: ...
+).call
+```
+
+Its return value should power both the UI and console diagnostics.
+
+The report must state its exact UTC window and aggregate only invocation-local
+usage.
+
+### Phase 3 tests
+
+#### Query/report tests
+
+1. Group interactions by logical session.
+2. Keep different Chaos processes within one logical session visible.
+3. Sum invocation-local usage exactly once.
+4. Do not include process-cumulative diagnostic totals in token sums.
+5. Group by trigger kind, provider, model, outcome, and roll reason.
+6. Report unknown/incomplete rows separately.
+7. Apply exact UTC boundaries.
+
+#### Controller/view tests
+
+1. Administrators can access the diagnostics.
+2. Ordinary account users cannot access it unless explicitly authorised.
+3. Session summary displays lifecycle and all token categories.
+4. Session detail displays chronological interactions.
+5. Missing telemetry displays as unknown, not zero.
+6. Raw invocation, identity, transcript, and tool-output contents are not shown
+   on the summary page.
+7. Filters preserve UTC range and grouping.
+
+#### Performance test
+
+Create a realistic number of interactions and assert the summary avoids one
+query per session/interaction. Add indexes only after checking the actual query
+plan.
+
+Likely useful indexes:
+
+```text
+(agent_id, started_at)
+(agent_id, session_id, started_at)
+(agent_id, chaos_session_id, started_at)
+(agent_id, session_outcome, started_at)
+```
+
+### Phase 3 exit criteria
+
+- An administrator can identify expensive logical sessions without a console.
+- The screen distinguishes HelixKit sessions, Chaos processes, and provider
+  requests.
+- Token totals are traceable to individual interactions.
+- Session churn and long-context cache-read growth are visible.
+- Missing telemetry is visible rather than silently excluded.
+
+---
+
+## Phase 4 — End-to-end verification and deployment
+
+### Consumer-before-producer deployment
+
+1. Deploy HelixKit migrations and tolerant recording code.
+2. Deploy shim lifecycle telemetry.
+3. Merge and pin the instrumented Chaos commit in the runtime image.
+4. Build and deploy the hosted runtime through the normal Kamal workflow.
+5. Use a disposable agent for verification.
+6. Enable the diagnostics screen.
+7. Observe at least one full day before choosing cost optimisations.
+
+Do not mutate production containers manually.
+
+### Disposable-agent test
+
+1. Start a new logical conversation session.
+   - fresh;
+   - full prompt;
+   - one Chaos process;
+   - invocation-local usage present.
+2. Send a second message.
+   - resumed;
+   - same Chaos process;
+   - delta prompt;
+   - cache read visible.
+3. Cause a tool-using response.
+   - provider request count greater than one;
+   - invocation total includes all calls.
+4. Exercise the Stop hook.
+   - invocation total includes it;
+   - if attribution is not yet available, no phase is fabricated.
+5. Touch an identity file without changing bytes.
+   - no roll.
+6. Change `self-narrative.md` bytes.
+   - one identity roll;
+   - changed filename visible.
+7. Change model.
+   - one model roll;
+   - new Chaos process.
+8. Open the diagnostics UI.
+   - one logical session;
+   - multiple interactions;
+   - process transition visible;
+   - token totals equal the sum of interaction rows.
+9. Compare one exact UTC window with the provider dashboard.
+   - use only traffic generated after the new contract was deployed;
+   - do not attempt to reconcile earlier usage.
+
+### What to decide after observation
+
+Only after the instrumentation is trusted should we decide whether to:
+
+- gate or fold the Stop reflex;
+- shorten cache TTL for bursty conversation/Telegram sessions;
+- retain a longer TTL for scheduled wakes;
+- compact or deliberately roll long sessions;
+- alter the stable prompt/cache-breakpoint architecture;
+- reduce false session churn further.
+
+---
+
+## Important risks and safeguards
+
+### Ambiguous usage scope
+
+This is the largest technical risk. A field named only `usage` is insufficient
+unless its scope is part of the contract and tested across resume.
+
+### Double counting
+
+Never add both invocation usage and process-cumulative usage into the same
+report.
+
+### Incomplete invocations
+
+Timeout and failure rows must be visible as incomplete. Their known usage may be
+recorded, but completeness must not be implied.
+
+### Provider variation
+
+Some providers may not expose cache categories or reasoning output. Preserve
+unknown values rather than forcing the Anthropic shape onto every provider.
+
+### Privacy
+
+Prompt sizes, hashes, process IDs, and token counts are useful without exposing
+prompt contents. Keep diagnostics admin-only until the exposure boundary has
+been reviewed.
+
+### UI conclusions before baseline
+
+Build the timeline before alarms. Do not encode guessed thresholds before real
+traffic establishes normal behaviour by trigger kind and model.
+
+---
+
+## Recommended implementation slices
+
+### Chaos slice A — Characterisation tests
+
+Deliverable:
+
+- executable proof of current simple/tool/resume usage semantics.
+
+### Chaos slice B — Usage fidelity
+
+Deliverable:
+
+- separate cache creation/read categories;
+- provider request count;
+- invocation-local, versioned completion usage.
+
+### HelixKit slice A — Capture
+
+Deliverable:
+
+- shim lifecycle and prompt telemetry;
+- versioned Chaos parser;
+- additive interaction persistence;
+- content-hash identity fingerprints.
+
+### HelixKit slice B — Reporting
+
+Deliverable:
+
+- UTC summary service;
+- logical-session summary screen;
+- interaction and Chaos-process timeline.
+
+### Integration slice
+
+Deliverable:
+
+- disposable-agent run whose UI totals reconcile with the emitted Chaos
+  invocation events and the provider dashboard for a post-deployment UTC
+  window.
+
+---
+
+## Definition of done
+
+1. Chaos tests prove what one invocation includes.
+2. Cache creation and cache read remain separate from the Anthropic adapter to
+   HelixKit storage.
+3. One invocation reports its own usage without HelixKit subtracting historical
+   process totals.
+4. Provider request count is accurate for simple, tool-using, and Stop-hook
+   invocations.
+5. Every new instrumented interaction explains fresh/resume/roll/fallback.
+6. Same-content identity rewrites do not roll sessions.
+7. HelixKit groups interactions by logical session while preserving Chaos
+   process transitions.
+8. The diagnostics screen shows token categories per session and per
+   interaction.
+9. Unknown and incomplete data are visibly distinct from zero.
+10. A post-deployment UTC window can be reconciled without recovering any
+    historical usage.

--- a/docs/requirements/20260718-hosted-agent-runtime-observability.md
+++ b/docs/requirements/20260718-hosted-agent-runtime-observability.md
@@ -1,0 +1,1204 @@
+# Hosted-agent runtime observability — session lifecycle and token accounting
+
+Date: 2026-07-18
+
+Status: implemented on 2026-07-18; deployment verification remains
+
+Related documents:
+
+- `docs/hosted-agent-token-economics-2026-07-14.md`
+- `docs/per-chat-session-resume-2026-07-15.md`
+- `agent-runtime/trigger_shim.py`
+- Chaos prompt-caching change `e2a6221f4` / merge `cbd489164`
+
+## Executive summary
+
+The immediate problem is no longer simply "prompt caching is absent." Anthropic
+prompt caching is enabled in Chaos, and stable resumed HelixKit sessions show
+very high cache-read ratios. The remaining bill is difficult to explain because
+the current telemetry loses two important distinctions:
+
+1. Chaos receives ordinary input, cache-creation input, and cache-read input as
+   separate provider counters, but collapses cache creation into the generic
+   `input_tokens` total before emitting `turn.completed`.
+2. HelixKit records whether the final result says a session was resumed, but not
+   the complete decision path: whether a mapping existed, whether resume was
+   attempted, which files changed, why a session rolled, how large the selected
+   prompt was, or how many provider requests the Chaos turn made.
+
+This means the first observability improvement spans both repositories:
+
+- **HelixKit and `trigger_shim.py` can instrument the session lifecycle without
+  changing Chaos.** The shim already makes the fresh/resume/roll/fallback
+  decisions and knows the prompt sizes and sidecar state.
+- **Exact cache-creation accounting requires a small Chaos contract change.**
+  The Anthropic adapter already has the number; Chaos currently discards its
+  separate identity before the JSONL event reaches the shim.
+- **Per-provider-request attribution may require a second, optional Chaos
+  change.** Start with aggregate counts. Add call-level events only if aggregate
+  cache creation plus lifecycle telemetry still cannot explain the bill.
+
+The proposed order is deliberately diagnostic:
+
+1. Persist the lifecycle facts the shim already knows.
+2. Preserve cache-creation tokens through Chaos's event contract.
+3. Add provider request counts and, only if needed, per-request usage events.
+4. Observe real traffic for at least a full day.
+5. Use those measurements to choose the actual cost fixes: reducing false
+   session rolls, changing cache TTLs, gating the Stop reflex, or compacting
+   long sessions.
+
+Do not optimize the journal loader or heartbeat cadence first. Current evidence
+does not support journal-file appends invalidating a successfully resumed
+session.
+
+---
+
+## Why this work is needed
+
+### What the July 17 investigation established
+
+The Fable interactions around conversation `oewxyj` showed:
+
+| Scope | Input tokens | Cache-read tokens | Cache-read ratio | Output tokens |
+|---|---:|---:|---:|---:|
+| First confirmed Fable interactions, 377–382 | 2,452,514 | 2,303,201 | 93.9% | 25,991 |
+| Stable resumed interactions, 379–382 | 1,845,785 | 1,797,168 | 97.4% | 17,452 |
+
+That is evidence that caching is functioning during stable resume. It is not
+evidence that the resulting economics are good: repeatedly reading a large
+cached context, producing expensive output, and writing every newly appended
+suffix can still cost a great deal.
+
+The same sequence contained three fresh starts:
+
+- Interaction 376: `identity-changed`
+- Interaction 377: `model-changed`
+- Interaction 378: `identity-changed`
+- Interaction 379 onward: stable resume
+
+Fresh interactions 376–378 each injected roughly 90–92 KB of initial prompt.
+The first resumed interaction sent only a roughly 3 KB delta.
+
+### Why the daily-journal cache-busting hypothesis does not fit the code
+
+On successful resume, `trigger_shim.py` sends:
+
+```text
+chaos exec --json ... resume <process_id> -
+```
+
+with `request_delta`, not `build_prompt(request)`. It does not:
+
+- re-read identity files;
+- re-read daily journals;
+- rebuild the initial HelixKit transcript;
+- put the changed journal file back into the model prefix.
+
+The Stop hook still costs money because it creates another continuation, often
+including a tool call that appends the journal. That adds cache reads, output,
+and a new suffix to cache. The file append itself does not rewrite the prior
+session prefix.
+
+On fresh sessions, the journal loader is already bounded:
+
+- most recent journal threshold: 12,000 characters;
+- most recent journal tail: 10,000 characters;
+- total journal context: 16,000 characters.
+
+The measured journal section in fresh interaction 378 was approximately 10.1
+KB, not the full 82 KB file on disk. Journal memory is also already placed after
+the live request/transcript in `build_prompt`.
+
+### The current accounting blind spot
+
+The Anthropic adapter currently parses:
+
+```rust
+input_tokens
+cache_creation_input_tokens
+cache_read_input_tokens
+output_tokens
+```
+
+but converts them to Chaos `TokenUsage` as:
+
+```rust
+input_tokens =
+  input_tokens +
+  cache_creation_input_tokens +
+  cache_read_input_tokens
+
+cached_input_tokens = cache_read_input_tokens
+```
+
+By the time `chaos exec --json` emits `turn.completed`, cache creation is no
+longer separately identifiable. The shim and HelixKit therefore receive:
+
+```json
+{
+  "input_tokens": 804276,
+  "cached_input_tokens": 778556,
+  "output_tokens": 10108
+}
+```
+
+but cannot tell how the remaining 25,720 input tokens divide between:
+
+- ordinary uncached input;
+- cache-creation input.
+
+This is exactly the distinction needed to reconcile HelixKit interactions with
+the provider dashboard's input/cache-read/cache-write categories.
+
+---
+
+## Questions the instrumentation must answer
+
+After this work, one interaction row should be enough to answer:
+
+1. Did HelixKit request persistence for this trigger?
+2. Which HelixKit logical session key was used?
+3. Did the shim find a sidecar mapping?
+4. Did it attempt resume?
+5. Did it run fresh, resume successfully, roll deliberately, or fall back after
+   a failed resume?
+6. If it rolled, exactly why?
+7. If identity changed, which fingerprinted files changed?
+8. Were the bytes actually different, or was only an mtime changed?
+9. What were the previous and resulting Chaos process IDs?
+10. Was the invocation sent as a full prompt or a delta?
+11. How large were the available full prompt, available delta, and selected
+    invocation?
+12. Which provider, model, and cache TTL were used?
+13. How old was the resumed session and how many HelixKit triggers had already
+    used it?
+14. How many provider requests occurred inside the Chaos turn?
+15. Across those requests, how many tokens were:
+    - ordinary uncached input;
+    - cache creation;
+    - cache read;
+    - output;
+    - reasoning output, if the provider exposes it?
+16. Did a Stop-hook continuation occur, and how much of the turn did it account
+    for?
+17. Can the aggregate be reconciled with the Anthropic usage dashboard for the
+    same time window?
+
+Questions 1–13 are primarily shim/HelixKit work. Questions 14–16 require Chaos
+to expose information that currently remains inside the process.
+
+---
+
+## Desired telemetry model
+
+### Keep three levels distinct
+
+The system currently blurs three different objects:
+
+1. **HelixKit interaction**
+   - One Rails request to the external runtime.
+   - Stored as `AgentRuntimeInteraction`.
+2. **Chaos process/session**
+   - Identified by `chaos_session_id` / Chaos `process_id`.
+   - Can span many HelixKit interactions through `exec resume`.
+3. **Provider request**
+   - One Anthropic Messages API call.
+   - A single Chaos turn may make several because of tools and the Stop-hook
+     continuation.
+
+The data model and names should preserve these levels. In particular,
+`provider_request_count` is not the same as HelixKit interaction count, and
+`session_resumed` is not the same as "the provider cache was read."
+
+### Canonical token semantics
+
+Use these names end to end:
+
+```text
+input_tokens
+  Total provider prompt tokens:
+  uncached_input_tokens + cache_creation_input_tokens + cache_read_input_tokens
+
+uncached_input_tokens
+  Ordinary input that was neither read from nor written to a prompt cache.
+
+cache_creation_input_tokens
+  Input tokens written into the provider prompt cache.
+
+cache_read_input_tokens
+  Input tokens served from the provider prompt cache.
+
+output_tokens
+  Provider output tokens.
+
+reasoning_output_tokens
+  Provider-reported reasoning/thinking output when separately available.
+```
+
+Keep `cached_input_tokens` as a temporary compatibility alias for
+`cache_read_input_tokens`; do not use the ambiguous name in new code or UI.
+
+For providers that do not expose a category, store `NULL`, not a fabricated
+zero. Zero means "the provider reported none"; `NULL` means "unknown or not
+available."
+
+### Do not make cost estimates the source of truth
+
+Persist tokens and lifecycle facts. Provider prices change, model aliases can
+move, and account-specific pricing may differ. A later reporting layer can
+estimate cost from a versioned price table, but the first implementation should
+not bake current Fable or Opus prices into interaction rows.
+
+---
+
+## Phase 1 — Shim-owned session lifecycle telemetry
+
+This phase can land in HelixKit without waiting for Chaos.
+
+### 1.1 Extend the shim response
+
+`agent-runtime/trigger_shim.py` should return a structured `session` object:
+
+```json
+{
+  "session": {
+    "logical_session_id": "<agent-uuid>-519",
+    "persistent_requested": true,
+    "mapping_found": true,
+    "resume_attempted": true,
+    "outcome": "resumed",
+    "roll_reason": null,
+    "changed_identity_files": [],
+    "prior_chaos_process_id": "019f...",
+    "chaos_process_id": "019f...",
+    "sidecar_created_at": "2026-07-17T15:20:19Z",
+    "sidecar_last_finished_at": "2026-07-17T15:27:42Z",
+    "session_age_seconds": 522,
+    "trigger_sequence": 5,
+    "fresh_fallback": false
+  },
+  "prompt": {
+    "mode": "delta",
+    "full_prompt_bytes": 92338,
+    "delta_prompt_bytes": 3145,
+    "selected_prompt_bytes": 3145
+  },
+  "runtime": {
+    "provider": "anthropic",
+    "model": "claude-fable-5",
+    "cache_ttl": "1h",
+    "timeout_seconds": 1800
+  }
+}
+```
+
+Suggested `session.outcome` values:
+
+- `legacy_fresh`
+- `fresh`
+- `resumed`
+- `rolled`
+- `fresh_fallback`
+- `resume_timeout`
+- `already_running`
+- `failed`
+
+Keep the existing top-level fields (`session_resumed`, `fresh_fallback`,
+`chaos_session_id`) during migration for backwards compatibility.
+
+### 1.2 Record the complete decision, not only the final state
+
+The shim should build a lifecycle record at the start of `persistent_trigger`
+and update it as decisions happen. This avoids reconstructing intent after the
+fact.
+
+Examples:
+
+- A model change should record:
+  - mapping found: true;
+  - resume attempted: false;
+  - outcome: rolled;
+  - roll reason: model-changed;
+  - previous and new process IDs.
+- A stale mapping should record:
+  - mapping found: true;
+  - resume attempted: true;
+  - returned process ID did not match;
+  - outcome: fresh-fallback;
+  - roll reason: resume-failed.
+- A timeout should record:
+  - resume attempted: true;
+  - outcome: resume-timeout;
+  - mapping retired: true.
+
+### 1.3 Replace mtime-only fingerprints with content fingerprints
+
+The current identity fingerprint stores `st_mtime_ns` for:
+
+- `soul.md`
+- `runtime-instructions.md`
+- `self-narrative.md`
+- `bootstrap.md`
+
+This can roll every session when deployment or synchronization rewrites an
+unchanged file. Replace each value with:
+
+```json
+{
+  "sha256": "...",
+  "bytes": 28114
+}
+```
+
+Do not include mtimes in the equality check. An mtime may remain as diagnostic
+metadata, but bytes determine whether identity changed.
+
+When comparing a sidecar record with current identity, return both:
+
+```python
+roll_reason = "identity-changed"
+changed_identity_files = ["self-narrative.md"]
+```
+
+This has two benefits:
+
+- prevents false cold starts caused by same-content rewrites;
+- distinguishes a genuine self-narrative update from a runtime instruction or
+  bootstrap change.
+
+Content hashes are safe to persist; raw identity contents are not needed in the
+lifecycle telemetry.
+
+### 1.4 Add sidecar schema version and sequence
+
+Add to each session sidecar:
+
+```json
+{
+  "schema_version": 2,
+  "trigger_sequence": 5
+}
+```
+
+The shim should read version-1 records defensively and upgrade them on the next
+successful write. Unknown future versions should retire safely and start fresh
+with a clear `sidecar-schema-unsupported` roll reason.
+
+### 1.5 Prompt-size telemetry
+
+Record byte counts, not prompt contents:
+
+- `full_prompt_bytes`
+- `delta_prompt_bytes`
+- `selected_prompt_bytes`
+- optional component sizes on fresh prompts:
+  - `identity_prompt_bytes`
+  - `request_prompt_bytes`
+  - `journal_prompt_bytes`
+
+Component sizes make claims such as "the journal loaded 82 KB" directly
+verifiable without storing another copy of private prompt text.
+
+### 1.6 Cache TTL telemetry
+
+The shim should report the effective TTL passed to Chaos:
+
+```text
+off | 5m | 1h | unknown
+```
+
+Today the adapter can take it from a request extension or
+`CHAOS_ANTHROPIC_CACHE_TTL`. The selected value must be visible per interaction
+before experimenting with trigger-specific TTLs.
+
+---
+
+## Phase 2 — HelixKit persistence and diagnostics
+
+### 2.1 Schema changes
+
+Add additive columns to `agent_runtime_interactions`:
+
+```ruby
+add_column :agent_runtime_interactions, :provider, :string
+add_column :agent_runtime_interactions, :model, :string
+add_column :agent_runtime_interactions, :cache_ttl, :string
+
+add_column :agent_runtime_interactions, :persistent_session_requested, :boolean
+add_column :agent_runtime_interactions, :session_mapping_found, :boolean
+add_column :agent_runtime_interactions, :resume_attempted, :boolean
+add_column :agent_runtime_interactions, :session_outcome, :string
+add_column :agent_runtime_interactions, :session_roll_reason, :string
+add_column :agent_runtime_interactions, :changed_identity_files, :jsonb, default: []
+add_column :agent_runtime_interactions, :prior_chaos_session_id, :string
+add_column :agent_runtime_interactions, :session_trigger_sequence, :integer
+add_column :agent_runtime_interactions, :session_age_seconds, :integer
+
+add_column :agent_runtime_interactions, :prompt_mode, :string
+add_column :agent_runtime_interactions, :full_prompt_bytes, :integer
+add_column :agent_runtime_interactions, :delta_prompt_bytes, :integer
+add_column :agent_runtime_interactions, :selected_prompt_bytes, :integer
+add_column :agent_runtime_interactions, :prompt_component_bytes, :jsonb, default: {}
+
+add_column :agent_runtime_interactions, :uncached_input_tokens, :bigint
+add_column :agent_runtime_interactions, :cache_creation_input_tokens, :bigint
+add_column :agent_runtime_interactions, :cache_read_input_tokens, :bigint
+add_column :agent_runtime_interactions, :reasoning_output_tokens, :bigint
+add_column :agent_runtime_interactions, :provider_request_count, :integer
+```
+
+Existing `input_tokens`, `cached_input_tokens`, and `output_tokens` remain.
+`cached_input_tokens` should be populated alongside
+`cache_read_input_tokens` during compatibility.
+
+Indexes worth adding:
+
+```ruby
+add_index :agent_runtime_interactions, [:agent_id, :started_at]
+add_index :agent_runtime_interactions, [:agent_id, :chaos_session_id]
+add_index :agent_runtime_interactions, [:agent_id, :session_outcome]
+add_index :agent_runtime_interactions, [:agent_id, :session_roll_reason]
+```
+
+The first may already be covered; check the schema before adding duplicates.
+
+### 2.2 Store structured telemetry in `record_result!`
+
+`AgentRuntimeInteraction#record_result!` should:
+
+1. Extract `session`, `prompt`, `runtime`, and `usage`.
+2. Persist their scalar fields.
+3. Keep the full response body for short-term debugging as today.
+4. Tolerate old runtime images that do not send the new objects.
+5. Derive `uncached_input_tokens` only when all necessary provider categories
+   are known:
+
+```ruby
+input - cache_creation - cache_read
+```
+
+Never derive it from `input - cache_read` after cache-creation support lands;
+that repeats the current ambiguity.
+
+### 2.3 Add model-level helpers
+
+Useful methods:
+
+```ruby
+interaction.cache_read_ratio
+interaction.cache_creation_ratio
+interaction.fresh_session?
+interaction.resumed_session?
+interaction.cold_start?
+interaction.provider_requests_per_trigger
+interaction.token_breakdown
+```
+
+Ratios should return `nil` when the denominator or category is unknown.
+
+### 2.4 Admin-only diagnostics
+
+Do not add raw runtime diagnostics to public chat activity JSON.
+
+Add an administrator-only runtime diagnostics view or endpoint containing:
+
+- lifecycle badge: fresh / resumed / rolled / fallback;
+- logical session key and Chaos process ID;
+- roll reason and changed filenames;
+- prompt mode and byte sizes;
+- provider/model/cache TTL;
+- token category table;
+- provider request count;
+- duration;
+- links to adjacent interactions in the same logical and Chaos sessions.
+
+The existing `full_invocation_text`, stdout, stderr, and response body can
+contain identity, transcript, commands, and tool output. They must remain behind
+the existing admin/debug authorization boundary. The new metrics are safer, but
+should initially live behind the same boundary while their exposure is reviewed.
+
+### 2.5 A session timeline view
+
+The most useful diagnostic is not an isolated row but a session timeline:
+
+```text
+15:14 conversation  fresh   model-changed     process A  full 90 KB
+15:20 conversation  fresh   identity-changed  process B  full 92 KB
+15:22 conversation  resumed                   process B  delta 3 KB
+15:24 conversation  resumed                   process B  delta 4 KB
+15:27 conversation  resumed                   process B  delta 2 KB
+15:29 conversation  resumed                   process B  delta 3 KB
+```
+
+For each row, show:
+
+```text
+ordinary input / cache write / cache read / output / provider calls
+```
+
+This makes cold-start fan-out and long-session growth visible immediately.
+
+---
+
+## Phase 3 — Preserve cache creation through Chaos
+
+This is the minimum Chaos change.
+
+### 3.1 Extend canonical `TokenUsage`
+
+Chaos's canonical token contract currently has:
+
+```rust
+pub struct TokenUsage {
+    pub input_tokens: i64,
+    pub cached_input_tokens: i64,
+    pub output_tokens: i64,
+    pub reasoning_output_tokens: i64,
+    pub total_tokens: i64,
+}
+```
+
+Add:
+
+```rust
+pub cache_creation_input_tokens: i64,
+```
+
+Prefer also renaming or documenting:
+
+```rust
+cached_input_tokens == cache_read_input_tokens
+```
+
+Do not make a breaking rename immediately. Add a helper:
+
+```rust
+pub fn cache_read_input(&self) -> i64
+```
+
+and preserve the serialized `cached_input_tokens` field until downstream users
+have migrated.
+
+Likely affected Chaos files include:
+
+- `lib/libcontract/ipc/src/protocol/events_token.rs`
+- ABI/provider token usage types, if separately defined
+- session token accumulation and display helpers
+- serialization/TypeScript snapshots
+- tests constructing `TokenUsage` literals
+
+`add_assign`, defaulting, and any blended-total calculations must include or
+deliberately exclude the new field according to their documented semantics.
+`input_tokens` should remain the complete prompt total; cache creation is a
+subset, just as cache read is.
+
+### 3.2 Preserve the Anthropic counter
+
+`UsageAccumulator` in:
+
+```text
+sys/kern/providers/parrot/src/anthropic.rs
+```
+
+already stores `cache_creation_input_tokens`. Its `token_usage()` method should
+set the new field rather than discard the distinction:
+
+```rust
+TokenUsage {
+    input_tokens: prompt_tokens as i64,
+    cache_creation_input_tokens: self.cache_creation_input_tokens as i64,
+    cached_input_tokens: self.cache_read_input_tokens as i64,
+    output_tokens: self.output_tokens as i64,
+    ...
+}
+```
+
+Other providers should leave the field at zero or unknown according to what
+their adapters actually report. The outer HelixKit contract may use `NULL` for
+unsupported providers even if Chaos's internal struct defaults to zero.
+
+### 3.3 Extend `chaos exec --json`
+
+`sys/exec/fork/src/exec_events.rs` currently emits:
+
+```rust
+pub struct Usage {
+    pub input_tokens: i64,
+    pub cached_input_tokens: i64,
+    pub output_tokens: i64,
+}
+```
+
+Add:
+
+```rust
+pub cache_creation_input_tokens: i64,
+pub reasoning_output_tokens: i64,
+pub provider_request_count: i64,
+```
+
+The JSONL should become:
+
+```json
+{
+  "type": "turn.completed",
+  "usage": {
+    "input_tokens": 804276,
+    "cache_creation_input_tokens": 12140,
+    "cached_input_tokens": 778556,
+    "output_tokens": 10108,
+    "reasoning_output_tokens": 0,
+    "provider_request_count": 5
+  }
+}
+```
+
+All fields should be additive and default safely so older consumers continue to
+work.
+
+### 3.4 Count provider requests
+
+Increment a counter whenever Chaos dispatches a model provider request, not
+whenever a HelixKit trigger, Chaos turn, tool, or output item occurs.
+
+This count closes a major explanatory gap:
+
+- 800 K input over one HelixKit interaction may be one enormous request or five
+  repeated reads of a 160 K context.
+- The cost remedies are different in those cases.
+
+The counter should aggregate across the primary turn and Stop-hook
+continuations included in the `chaos exec` lifecycle.
+
+### 3.5 Compatibility and versioning
+
+The shim must accept both old and new `turn.completed` shapes:
+
+```python
+cache_creation_input_tokens = usage.get("cache_creation_input_tokens")
+provider_request_count = usage.get("provider_request_count")
+```
+
+Missing fields remain `None`; do not silently claim zero cache writes for old
+Chaos versions.
+
+The shim health response should expose the Chaos version/commit sufficiently to
+tell whether the runtime supports detailed usage.
+
+---
+
+## Phase 4 — Optional per-provider-request usage events
+
+Do not make this a prerequisite for the first deployment.
+
+Aggregate per-trigger counts may be enough to explain the bill. If not, add an
+additive JSONL event:
+
+```json
+{
+  "type": "model.usage",
+  "request_sequence": 4,
+  "phase": "stop_hook",
+  "usage": {
+    "input_tokens": 171220,
+    "uncached_input_tokens": 1420,
+    "cache_creation_input_tokens": 3800,
+    "cache_read_input_tokens": 166000,
+    "output_tokens": 620
+  }
+}
+```
+
+Suggested `phase` values:
+
+- `primary`
+- `tool_continuation`
+- `stop_hook`
+- `compaction`
+- `unknown`
+
+Only emit a phase if Chaos can determine it reliably. Incorrect attribution is
+worse than `unknown`.
+
+The shim can aggregate these into:
+
+```json
+"provider_requests": [
+  {
+    "sequence": 1,
+    "phase": "primary",
+    "usage": { ... }
+  }
+]
+```
+
+HelixKit can initially store the array in a `jsonb` column rather than creating
+a second table. If the arrays become large or need querying at scale, normalize
+them into `agent_runtime_provider_requests` later.
+
+### Why this phase is optional
+
+The first three phases already reveal:
+
+- cold starts;
+- false identity invalidations;
+- prompt size;
+- aggregate cache creation;
+- cache-read ratio;
+- model-call count.
+
+Per-request detail is justified only if we still cannot tell whether the Stop
+hook, tools, compaction, or ordinary response generation dominates.
+
+---
+
+## Phase 5 — Verification and operational reporting
+
+### 5.1 Reconciliation report
+
+Add a Rails service or console-friendly query that summarizes a time range:
+
+```ruby
+AgentRuntimeUsageReport.new(
+  agent: agent,
+  from: 1.day.ago,
+  to: Time.current
+).call
+```
+
+Expected output:
+
+```text
+HelixKit interactions: 48
+Fresh sessions: 4
+Resumed sessions: 42
+Rolls:
+  identity-changed: 2
+  model-changed: 1
+  resume-failed: 1
+
+Provider requests: 137
+Input:
+  ordinary: 182,000
+  cache creation: 301,000
+  cache read: 9,430,000
+Output: 54,000
+
+Prompt bytes:
+  fresh full total: ...
+  resumed delta total: ...
+```
+
+The report should group by:
+
+- trigger kind: wake / conversation / Telegram / aggregation;
+- session outcome;
+- model;
+- Chaos process ID;
+- hour.
+
+This will make it possible to compare the same UTC window with the provider
+dashboard without manually summing rows.
+
+### 5.2 Derived alarms
+
+After baseline data exists, add warnings rather than hard policy:
+
+- more than one fresh start for the same logical session in an hour;
+- identity-changed roll with no changed content hash;
+- cache-read ratio below an expected threshold on a resumed session;
+- unusually high cache creation on a resumed interaction;
+- provider request count much higher than normal for the trigger kind;
+- selected delta prompt unexpectedly close to full-prompt size;
+- repeated `fresh_fallback` or `resume-timeout`.
+
+Thresholds must be based on observed traffic, not guessed in the first patch.
+
+---
+
+## Test plan
+
+### Chaos unit tests
+
+1. Anthropic SSE usage preserves all four categories:
+   - ordinary input;
+   - cache creation;
+   - cache read;
+   - output.
+2. `TokenUsage#add_assign` sums cache creation correctly.
+3. JSON serialization includes the new field.
+4. `turn.completed` emits cache creation, reasoning output, and provider request
+   count.
+5. Older/default provider usage produces safe defaults.
+6. A multi-call tool turn increments provider request count once per actual
+   provider dispatch.
+7. If phase attribution is added, Stop-hook and ordinary calls are labelled
+   correctly.
+
+### Shim tests
+
+Extend `test/lib/trigger_shim_session_test.rb`:
+
+1. `parse_events` extracts cache creation and provider request count.
+2. Cumulative-to-per-trigger subtraction handles the new counters.
+3. Counter reset logic handles each new counter independently.
+4. First persistent trigger records `fresh`.
+5. Second trigger records `resumed`, mapping found, resume attempted, same
+   process ID, and delta prompt mode.
+6. Model change records `rolled` / `model-changed` without a resume attempt.
+7. Provider change records `provider-changed`.
+8. Same-content file touch does not roll after content hashing.
+9. Actual identity byte change rolls and names the changed file.
+10. Stale process ID records both the failed resume attempt and fresh fallback.
+11. Timeout records mapping retirement and `resume-timeout`.
+12. Sidecar schema-v1 records upgrade safely.
+13. Full/delta/selected prompt byte counts are accurate.
+14. Missing new Chaos fields remain unknown rather than becoming false zeros.
+
+### Rails tests
+
+1. Migration defaults are correct.
+2. `record_result!` persists the structured lifecycle objects.
+3. Old shim responses remain valid.
+4. Token helpers distinguish unknown from zero.
+5. Usage reports group correctly by trigger kind, session outcome, and model.
+6. Admin diagnostics show the new metrics.
+7. Non-admin routes and chat activity JSON do not expose raw invocation,
+   response body, identity hashes, or process diagnostics.
+
+### End-to-end disposable-agent test
+
+Use a disposable hosted agent rather than experimenting against Claude's live
+identity:
+
+1. Deploy the instrumented runtime through the normal Kamal/image path.
+2. Trigger a new conversation:
+   - assert fresh session;
+   - assert full prompt mode;
+   - assert cache creation is reported.
+3. Trigger it again within the cache TTL:
+   - assert same Chaos process ID;
+   - assert resumed;
+   - assert delta mode;
+   - assert cache reads are non-zero.
+4. Touch a fingerprinted identity file without changing bytes:
+   - assert no roll.
+5. Change `self-narrative.md` bytes:
+   - assert `identity-changed`;
+   - assert changed filename is recorded;
+   - assert one fresh start.
+6. Change model:
+   - assert `model-changed`;
+   - assert new Chaos process ID.
+7. Exercise a tool-using response and a Stop reflex:
+   - assert provider request count increases;
+   - if Phase 4 exists, inspect per-request phases.
+8. Compare the interaction totals with the provider dashboard over the same
+   exact UTC interval.
+
+Do not mutate or inspect production containers manually. Build and deploy the
+instrumented image through the existing Kamal workflow so the test exercises
+the same lifecycle production will use.
+
+---
+
+## Deployment order
+
+The changes are additive, so deploy consumers before producers:
+
+1. **HelixKit migration and tolerant parser**
+   - New columns exist.
+   - Old runtime responses still work.
+2. **Shim lifecycle telemetry**
+   - Session facts and prompt sizes become visible immediately.
+   - No Chaos dependency.
+3. **Chaos token contract**
+   - Add cache creation and provider request count.
+   - Merge and pin the new Chaos commit in `agent-runtime/Dockerfile`.
+4. **Build and deploy the runtime image via Kamal**
+   - No manual mutation of running containers.
+5. **Disposable-agent verification**
+6. **Observe at least one full day**
+7. **Choose optimization work from the measured report**
+
+Self-hosted/externally deployed agents running an older runtime image will
+continue reporting the old shape. The diagnostics UI should display a clear
+"runtime does not report detailed cache usage" state until those agents are
+rebuilt through their normal deployment process.
+
+---
+
+## Decisions this instrumentation should enable
+
+### A. Are identity changes causing avoidable cold-start fan-out?
+
+Evidence:
+
+- frequent `identity-changed` rolls;
+- same changed filename across wake/chat/Telegram sessions;
+- content hash unchanged or file rewritten by deployment.
+
+Likely fix:
+
+- content hashes eliminate false rolls;
+- consider delivering genuine self-narrative changes as an appended identity
+  update rather than rolling every active session, but only after measuring the
+  fan-out and reviewing the semantic trade-off.
+
+### B. Is the Stop reflex the main marginal cost?
+
+Evidence:
+
+- provider request count increases materially on otherwise simple triggers;
+- Phase-4 events attribute significant read/write/output to `stop_hook`.
+
+Possible fixes:
+
+- fold the invitation into the primary turn;
+- skip it for locally identifiable no-op heartbeats;
+- fire only after substantive actions;
+- cap journal-entry length.
+
+The target is the extra model continuation, not the journal file append.
+
+### C. Are long sessions dominated by cache-read volume?
+
+Evidence:
+
+- stable resume;
+- low cache creation;
+- high cache reads;
+- provider request count multiplied by a large session context;
+- cost rises with session age despite small deltas.
+
+Possible fix:
+
+- compact or roll sessions at a measured context threshold, carrying forward a
+  concise summary plus transcript cursor.
+
+### D. Is one-hour cache TTL overpaying for bursty conversations?
+
+Evidence:
+
+- most conversation provider requests and HelixKit replies occur within five
+  minutes;
+- substantial cache creation under a one-hour TTL;
+- little reuse between five minutes and one hour.
+
+Possible fix:
+
+- keep one-hour TTL for half-hourly wakes;
+- use a shorter TTL for conversation/Telegram bursts;
+- or select TTL adaptively from recent session cadence.
+
+Do not change TTL until it is recorded per interaction and cache-creation
+tokens are visible.
+
+### E. Are unavoidable fresh sessions failing to share stable identity cache?
+
+Evidence:
+
+- each new logical session pays a large cache creation for the same identity
+  bytes;
+- fresh prompt component metrics show identity dominates;
+- resumed economics are healthy but first-turn economics remain poor.
+
+Possible fix:
+
+- represent stable identity as a separately cacheable block or breakpoint in
+  Chaos rather than concatenating identity, volatile request, and journal into
+  one initial user message.
+
+This is a deeper prompt-architecture change and should follow, not precede,
+basic instrumentation.
+
+---
+
+## Out of scope for the instrumentation patch
+
+- Changing heartbeat frequency.
+- Removing or weakening journals.
+- Changing the model.
+- Automatically compacting sessions.
+- Trigger-specific cache TTL policy.
+- Cost-based routing or cheap-model gates.
+- A shared global Chaos session across unrelated chats.
+- Provider price tables and authoritative dollar accounting.
+- Exposing raw prompts or identity contents to ordinary account users.
+
+Those may become sensible follow-ups. The purpose of this patch is to make the
+choice evidence-based.
+
+---
+
+## Recommended implementation slices
+
+### Slice 1 — HelixKit/shim lifecycle facts
+
+Files:
+
+- `agent-runtime/trigger_shim.py`
+- `test/lib/trigger_shim_session_test.rb`
+- migration for `agent_runtime_interactions`
+- `app/models/agent_runtime_interaction.rb`
+- admin runtime diagnostics/reporting
+
+Deliverable:
+
+- Every interaction explains fresh/resume/roll/fallback and prompt size.
+
+### Slice 2 — Chaos aggregate usage fidelity
+
+Files:
+
+- Anthropic adapter usage mapping
+- canonical `TokenUsage`
+- Chaos exec `Usage` JSONL contract
+- token accumulation/event processor tests
+
+Deliverable:
+
+- `turn.completed` preserves cache creation and provider request count.
+
+### Slice 3 — Reporting and one-day observation
+
+Files:
+
+- `AgentRuntimeUsageReport`
+- admin session timeline
+- tests and operational documentation
+
+Deliverable:
+
+- A UTC-window report reconcilable with the provider dashboard.
+
+### Slice 4 — Optional provider-call detail
+
+Only start if Slice 3 leaves a material unexplained remainder.
+
+Deliverable:
+
+- Per-provider-request usage and reliable primary/tool/Stop attribution.
+
+---
+
+## Success criteria
+
+The instrumentation is complete when:
+
+1. A fresh interaction visibly explains why it was fresh.
+2. An identity roll names the changed file and ignores same-content touches.
+3. A resumed interaction visibly shows full-versus-delta prompt sizes.
+4. Cache creation and cache reads are separate token fields.
+5. The number of provider requests inside one Chaos turn is known.
+6. Old runtime images remain compatible and display unknown fields honestly.
+7. A disposable-agent run can reconcile HelixKit totals with the provider
+   dashboard over the same UTC interval.
+8. The diagnostics remain admin-only and do not expand access to identity,
+   transcript, command, or tool-output contents.
+9. We can answer, from stored data rather than inference, which next change has
+   the largest expected effect.
+
+One-sentence version:
+
+> Instrument the three boundaries separately — HelixKit trigger, Chaos session,
+> and provider request — and preserve cache creation before Chaos collapses it,
+> so the next cost fix follows the bytes rather than the most plausible story.
+
+---
+
+## Appendix — review notes (Lume, 2026-07-18)
+
+Reviewed against `trigger_shim.py`, the Chaos source
+(`anthropic.rs`, `events_token.rs`), the restored production database, and the
+Anthropic dashboard for Jul 17–18. Every factual claim in the plan checks out:
+the mtime-only fingerprint (`trigger_shim.py:474`), the delta-resume path, the
+bounded journal loader (12K/10K/16K), and the cache-creation collapse
+(`anthropic.rs:525` folds `cache_creation_input_tokens` into `input_tokens`
+via `saturating_add`; `TokenUsage` has no separate field).
+
+### A hand reconciliation, attempted and half-failed
+
+The strongest evidence for this plan is what happens when you try to do
+Phase 5 by hand today. For Jul 17, at Fable pricing ($10/MTok input,
+$20/MTok 1h cache write, $1/MTok cache read, $50/MTok output):
+
+- **Input side reconciles within ~4%.** Dashboard: $3.92 input + $6.17 write
+  → 392K ordinary + 308K written ≈ 700K tokens. DB blended
+  `input_tokens − cached_input_tokens` = 726K. The blend is real and the
+  split is recoverable once the categories are preserved.
+- **Reads and output do not reconcile.** DB records 14.76M cache-read tokens
+  against a dashboard-implied 4.27M; 88K output against an implied 48K.
+- The likely explanation is that part of the day's traffic ran on a different
+  model and the dashboard view was filtered — but the current schema cannot
+  confirm or refute this. The recording pipeline is basically sound (the
+  input side proves that); the failure is confined to exactly the missing
+  distinctions this plan adds.
+
+Also visible in the dashboard: **cache write is the single largest line item
+on both days** ($6.17 of $16.76 on Jul 17; $3.09 of $8.63 on Jul 18), not
+cache read. That makes decisions B (Stop reflex → extra suffix writes) and D
+(1h TTL doubling the write price for bursty conversations) the leading
+candidates — to be confirmed by measurement, not assumed.
+
+### Gaps to fold into the slices
+
+1. **The legacy trigger path is uninstrumented — and it runs daily.**
+   `legacy_trigger()` invokes chaos with `json_output=False` and records no
+   usage, ever. `memory_aggregation_daily` goes through it every day
+   (~42K-char prompt, NULL tokens in `agent_runtime_interactions`).
+   Success criterion 7 (dashboard reconciliation) can never fully balance
+   while a daily job is invisible. Fix in Slice 1: run legacy triggers with
+   `--json` too and persist their usage.
+
+2. **Timeout paths lose their spend.** A resume/exec timeout kills the
+   subprocess and returns without usage, but the provider billed everything
+   consumed before the kill. `subprocess.TimeoutExpired` carries the partial
+   stdout (`e.stdout`) — the shim can parse events from it and salvage the
+   usage counters. At minimum, the reconciliation report should state that
+   timed-out interactions are a known undershoot. (3 conversation + 1 wake
+   NULL-usage rows since Jul 16 are likely this.)
+
+3. **Verify the cumulative-counter assumption itself.** `usage_since()`
+   assumes Chaos's `turn.completed` counters are process-lifetime cumulative
+   across resumes. The test plan covers the subtraction arithmetic but not
+   the underlying assumption. If Chaos actually reports per-exec usage,
+   every resumed interaction silently under-records — one candidate
+   explanation for the reads mismatch above. Add one Chaos-side test:
+   resume a process, assert the second `turn.completed` includes the first
+   turn's tokens.
+
+4. **Pull §1.3 (content-hash fingerprints) forward.** Since Jul 16 the data
+   shows 9 `identity-changed` rolls. If even half are mtime-only false rolls
+   (deployment/sync rewriting unchanged bytes), each costs a ~90KB fresh
+   prompt plus a full-context cache write at $20/MTok, fanned out across
+   wake/chat/telegram sessions. This is the one behavior change inside an
+   otherwise measurement-only patch — small, independently shippable, and
+   probably worth real money immediately. Suggest it lands as a "Slice 0"
+   together with item 1.
+
+5. **Make the reconciliation window explicitly UTC.** `started_at` is
+   `timestamp without time zone`; confirm it is UTC end to end before
+   comparing against dashboard days, and have `AgentRuntimeUsageReport`
+   state its window in UTC.
+
+6. **Rank the session-timeline view (§2.5) above the derived alarms (§5.2).**
+   Jul 17 shows healthy long-lived resume on wakes (48 triggers, 3 chaos
+   sessions) but more churn on conversations (22 triggers, 6 sessions). The
+   timeline is the diagnostic that makes that churn legible; the alarms can
+   wait for baseline data, as the plan already says.
+
+### Endorsed as-is
+
+The three-level model (interaction / chaos session / provider request);
+`provider_request_count` as the closer of the "one 800K request or five reads
+of 160K?" gap; NULL-means-unknown; tokens-not-dollars; Phase 4 deferred;
+deploy-consumers-first; and the rejection of the journal cache-busting
+hypothesis, which the code confirms.
+
+**Suggested slice order:** (0) content-hash fingerprints + instrument the
+legacy path → (1) shim lifecycle telemetry → (2) Chaos token contract + the
+cumulative-counter verification test → (3) reporting with explicit UTC
+windows. The failed hand-reconciliation above is the before-picture;
+success criterion 7 is the after.

--- a/test/controllers/admin/agent_runtime_sessions_controller_test.rb
+++ b/test/controllers/admin/agent_runtime_sessions_controller_test.rb
@@ -75,6 +75,46 @@ class Admin::AgentRuntimeSessionsControllerTest < ActionDispatch::IntegrationTes
     assert_equal "2026-07-18T12:00:00Z", inertia_shared_props.dig("filters", "to")
   end
 
+  test "normalizes a backwards UTC window instead of raising" do
+    login_as(@site_admin)
+
+    get admin_agent_runtime_path(@agent), params: {
+      from: "2026-07-18T14:00:00Z",
+      to: "2026-07-18T12:00:00Z"
+    }
+
+    assert_response :success
+    assert_equal "2026-07-17T12:00:00Z", inertia_shared_props.dig("filters", "from")
+    assert_equal "2026-07-18T12:00:00Z", inertia_shared_props.dig("filters", "to")
+  end
+
+  test "ignores malformed timestamp parameters" do
+    login_as(@site_admin)
+
+    get admin_agent_runtime_path(@agent), params: {
+      from: { unexpected: "value" },
+      to: "not-a-time"
+    }
+
+    assert_response :success
+    from = Time.iso8601(inertia_shared_props.dig("filters", "from"))
+    to = Time.iso8601(inertia_shared_props.dig("filters", "to"))
+    assert_in_delta 24.hours, to - from, 1.second
+  end
+
+  test "limits reports to a 31 day UTC window" do
+    login_as(@site_admin)
+
+    get admin_agent_runtime_path(@agent), params: {
+      from: "2026-01-01T00:00:00Z",
+      to: "2026-07-18T12:00:00Z"
+    }
+
+    assert_response :success
+    assert_equal "2026-06-17T12:00:00Z", inertia_shared_props.dig("filters", "from")
+    assert_equal "2026-07-18T12:00:00Z", inertia_shared_props.dig("filters", "to")
+  end
+
   test "applies report dimensions and selects a logical session timeline" do
     @agent.agent_runtime_interactions.create!(
       trigger_kind: "wake",

--- a/test/controllers/admin/agent_runtime_sessions_controller_test.rb
+++ b/test/controllers/admin/agent_runtime_sessions_controller_test.rb
@@ -1,0 +1,127 @@
+require "test_helper"
+
+class Admin::AgentRuntimeSessionsControllerTest < ActionDispatch::IntegrationTest
+
+  setup do
+    @agent = agents(:research_assistant)
+    @site_admin = users(:site_admin_user)
+    @regular_user = users(:regular_user)
+  end
+
+  test "requires authentication" do
+    get admin_agent_runtime_path(@agent)
+
+    assert_redirected_to login_path
+  end
+
+  test "requires a site administrator" do
+    login_as(@regular_user)
+
+    get admin_agent_runtime_path(@agent)
+
+    assert_redirected_to root_path
+  end
+
+  test "renders a safe UTC session report for site administrators" do
+    interaction = @agent.agent_runtime_interactions.create!(
+      trigger_kind: "conversation",
+      session_id: "session-safe",
+      started_at: Time.current,
+      chaos_session_id: "chaos-safe",
+      session_outcome: "resumed",
+      prompt_mode: "delta",
+      selected_prompt_bytes: 1_024,
+      telemetry_schema_version: 1,
+      usage_scope: "invocation",
+      cache_read_input_tokens: 500,
+      output_tokens: 20,
+      provider_request_count: 2,
+      usage_complete: true,
+      request_text: "private prompt",
+      stdout: "private output",
+      full_invocation_text: "private identity and transcript"
+    )
+    login_as(@site_admin)
+
+    get admin_agent_runtime_path(@agent)
+
+    assert_response :success
+    assert_equal "admin/agent-runtime-sessions", inertia_component
+    props = inertia_shared_props
+    assert_equal @agent.to_param, props.dig("agent", "id")
+    assert_equal "UTC", props.dig("report", "window", "timezone")
+    assert_equal 1, props.dig("report", "summary", "interactions")
+
+    rendered_interaction = props.dig("report", "sessions", 0, "interactions", 0)
+    assert_equal interaction.to_param, rendered_interaction["id"]
+    assert_equal 500, rendered_interaction.dig("tokens", "cache_read_input_tokens")
+    assert_equal "complete", rendered_interaction["telemetry_state"]
+    assert_not rendered_interaction.key?("request_text")
+    assert_not rendered_interaction.key?("stdout")
+    assert_not rendered_interaction.key?("full_invocation_text")
+    assert_not rendered_interaction.key?("response_body")
+  end
+
+  test "accepts an explicit UTC window" do
+    login_as(@site_admin)
+
+    get admin_agent_runtime_path(@agent), params: {
+      from: "2026-07-18T10:00:00Z",
+      to: "2026-07-18T12:00:00Z"
+    }
+
+    assert_response :success
+    assert_equal "2026-07-18T10:00:00Z", inertia_shared_props.dig("filters", "from")
+    assert_equal "2026-07-18T12:00:00Z", inertia_shared_props.dig("filters", "to")
+  end
+
+  test "applies report dimensions and selects a logical session timeline" do
+    @agent.agent_runtime_interactions.create!(
+      trigger_kind: "wake",
+      session_id: "wake-session",
+      started_at: Time.current,
+      telemetry_schema_version: 1,
+      usage_scope: "invocation",
+      usage_complete: true,
+      provider: "anthropic",
+      model: "claude-fable-5",
+      session_outcome: "resumed"
+    )
+    @agent.agent_runtime_interactions.create!(
+      trigger_kind: "conversation",
+      session_id: "chat-session",
+      started_at: Time.current,
+      telemetry_schema_version: 1,
+      usage_scope: "invocation",
+      usage_complete: true,
+      provider: "openai",
+      model: "gpt-5.5",
+      session_outcome: "fresh"
+    )
+    login_as(@site_admin)
+
+    get admin_agent_runtime_path(@agent), params: {
+      trigger_kind: "wake",
+      provider: "anthropic",
+      session_id: "wake-session"
+    }
+
+    assert_response :success
+    props = inertia_shared_props
+    assert_equal 1, props.dig("report", "summary", "interactions")
+    assert_equal "wake-session", props.dig("report", "sessions", 0, "session_id")
+    assert_equal "wake-session", props["selected_session_id"]
+    assert_equal "wake", props.dig("filters", "trigger_kind")
+    assert_equal "anthropic", props.dig("filters", "provider")
+  end
+
+  private
+
+  def login_as(user)
+    post login_path, params: {
+      email_address: user.email_address,
+      password: "password123"
+    }
+  end
+
+end

--- a/test/lib/trigger_shim_session_test.rb
+++ b/test/lib/trigger_shim_session_test.rb
@@ -14,7 +14,7 @@ class TriggerShimSessionTest < ActiveSupport::TestCase
     assert_includes dockerfile, "COPY --from=builder /usr/local/bin/chaos_journald /usr/local/bin/chaos_journald"
   end
 
-  test "parse_events extracts process id, latest cumulative usage, and agent messages" do
+  test "parse_events keeps old cumulative usage explicitly legacy" do
     out = run_shim_python(<<~PY)
       events = "\\n".join([
         '{"type":"process.started","process_id":"pid-123"}',
@@ -32,28 +32,163 @@ class TriggerShimSessionTest < ActiveSupport::TestCase
     assert_equal 10, parsed["input_tokens"]
     assert_equal 140, parsed["cached_input_tokens"]
     assert_equal 3, parsed["output_tokens"]
+    assert_equal "legacy", parsed["telemetry_status"]
+    assert_nil parsed["usage"]
     assert_equal [ "hello" ], parsed["agent_messages"]
   end
 
-  test "session records round-trip and roll on provider, model, and identity changes" do
+  test "parse_events preserves versioned invocation usage and unknown values" do
     out = run_shim_python(<<~PY)
-      events = {"process_id": "pid-abc", "input_tokens": 50, "cached_input_tokens": 0, "output_tokens": 5}
-      usage = mod.usage_since(None, events)
-      mod.save_session_record("sess-1", "claude-opus-4-7", events, usage, provider="anthropic")
+      events = "\\n".join([
+        '{"type":"process.started","process_id":"pid-123"}',
+        '{"type":"turn.completed","telemetry_schema_version":1,"usage":' +
+          '{"scope":"invocation","input_tokens":100,"uncached_input_tokens":10,' +
+          '"cache_creation_input_tokens":20,"cache_read_input_tokens":70,' +
+          '"output_tokens":7,"provider_request_count":2}}',
+      ])
+      print(json.dumps(mod.parse_events(events)))
+    PY
+
+    parsed = JSON.parse(out)
+    assert_equal "detailed", parsed["telemetry_status"]
+    assert_equal 1, parsed["telemetry_schema_version"]
+    assert_equal "invocation", parsed.dig("usage", "scope")
+    assert_equal 20, parsed.dig("usage", "cache_creation_input_tokens")
+    assert_equal 70, parsed.dig("usage", "cache_read_input_tokens")
+    assert_equal 2, parsed.dig("usage", "provider_request_count")
+    assert_nil parsed.dig("usage", "reasoning_output_tokens")
+  end
+
+  test "unversioned additive Chaos counters remain available for compatibility subtraction" do
+    out = run_shim_python(<<~PY)
+      events = mod.parse_events(
+        '{"type":"turn.completed","usage":' +
+        '{"input_tokens":1000,"cache_creation_input_tokens":40,"cached_input_tokens":700,' +
+        '"output_tokens":20,"reasoning_output_tokens":4,"provider_request_count":5}}'
+      )
+      record = {
+        "cumulative_input_tokens": 900,
+        "cumulative_cache_creation_input_tokens": 25,
+        "cumulative_cached_input_tokens": 650,
+        "cumulative_cache_read_input_tokens": 650,
+        "cumulative_output_tokens": 18,
+        "cumulative_reasoning_output_tokens": 3,
+        "cumulative_provider_request_count": 4,
+      }
+      print(json.dumps({
+        "parsed": events["legacy_cumulative_usage"],
+        "invocation": mod.usage_since(record, events),
+      }))
+    PY
+
+    result = JSON.parse(out)
+    assert_equal 40, result.dig("parsed", "cache_creation_input_tokens")
+    assert_equal 700, result.dig("parsed", "cache_read_input_tokens")
+    assert_nil result.dig("parsed", "uncached_input_tokens")
+    assert_equal 15, result.dig("invocation", "cache_creation_input_tokens")
+    assert_equal 50, result.dig("invocation", "cache_read_input_tokens")
+    assert_equal 1, result.dig("invocation", "provider_request_count")
+    assert_equal 1, result.dig("invocation", "reasoning_output_tokens")
+  end
+
+  test "parse_events selects the final versioned completion and keeps cumulative diagnostics separate" do
+    out = run_shim_python(<<~PY)
+      events = "\\n".join([
+        '{"type":"turn.completed","telemetry_schema_version":1,"usage":' +
+          '{"scope":"invocation","input_tokens":10,"output_tokens":1}}',
+        '{"type":"invocation.completed","telemetry_schema_version":1,"usage":' +
+          '{"scope":"invocation","input_tokens":20,"uncached_input_tokens":0,' +
+          '"cache_creation_input_tokens":5,"cache_read_input_tokens":15,"output_tokens":2,' +
+          '"provider_request_count":3},"session_usage":' +
+          '{"scope":"process_cumulative","input_tokens":200,"output_tokens":20}}',
+      ])
+      print(json.dumps(mod.parse_events(events)))
+    PY
+
+    parsed = JSON.parse(out)
+    assert_equal 20, parsed.dig("usage", "input_tokens")
+    assert_equal 0, parsed.dig("usage", "uncached_input_tokens")
+    assert_equal 3, parsed.dig("usage", "provider_request_count")
+    assert_equal "process_cumulative", parsed.dig("session_usage", "scope")
+    assert_equal 200, parsed.dig("session_usage", "input_tokens")
+  end
+
+  test "parse_events rejects unsupported telemetry versions without inventing usage" do
+    out = run_shim_python(<<~PY)
+      event = '{"type":"turn.completed","telemetry_schema_version":99,"usage":' + \
+        '{"scope":"invocation","input_tokens":100}}'
+      print(json.dumps(mod.parse_events(event)))
+    PY
+
+    parsed = JSON.parse(out)
+    assert_equal "unsupported", parsed["telemetry_status"]
+    assert_equal 99, parsed["unsupported_telemetry_schema_version"]
+    assert_nil parsed["usage"]
+  end
+
+  test "the final completion event replaces earlier detailed telemetry" do
+    out = run_shim_python(<<~PY)
+      events = "\\n".join([
+        '{"type":"turn.completed","telemetry_schema_version":1,"usage":' +
+          '{"scope":"invocation","input_tokens":100}}',
+        '{"type":"invocation.completed","telemetry_schema_version":99,"usage":' +
+          '{"scope":"invocation","input_tokens":200}}',
+      ])
+      print(json.dumps(mod.parse_events(events)))
+    PY
+
+    parsed = JSON.parse(out)
+    assert_equal "unsupported", parsed["telemetry_status"]
+    assert_equal 99, parsed["telemetry_schema_version"]
+    assert_equal 99, parsed["unsupported_telemetry_schema_version"]
+    assert_nil parsed["usage"]
+    assert_nil parsed["session_usage"]
+  end
+
+  test "failed versioned invocations are explicitly incomplete" do
+    out = run_shim_python(<<~PY)
+      events = mod.parse_events(
+        '{"type":"turn.completed","telemetry_schema_version":1,"usage":' +
+        '{"scope":"invocation","input_tokens":100,"complete":true}}'
+      )
+      print(json.dumps({
+        "parsed": events["usage"],
+        "successful": mod.response_invocation_usage(events, 0),
+        "failed": mod.response_invocation_usage(events, 1),
+      }))
+    PY
+
+    result = JSON.parse(out)
+    assert_equal true, result.dig("parsed", "complete")
+    assert_equal true, result.dig("successful", "complete")
+    assert_equal false, result.dig("failed", "complete")
+  end
+
+  test "session records use content hashes and name changed identity files" do
+    out = run_shim_python(<<~PY)
+      events = mod.parse_events('{"type":"process.started","process_id":"pid-abc"}\\n' +
+        '{"type":"turn.completed","usage":{"input_tokens":50,"cached_input_tokens":0,"output_tokens":5}}')
+      mod.save_session_record("sess-1", "claude-opus-4-7", events, provider="anthropic")
       record = mod.load_session_record("sess-1")
       checks = {
         "loaded_pid": record["chaos_process_id"],
+        "schema_version": record["schema_version"],
         "cumulative_input_tokens": record["cumulative_input_tokens"],
+        "soul_fingerprint": record["identity_fingerprint"]["soul.md"],
         "same_model": mod.roll_reason(record, "claude-opus-4-7", "anthropic"),
         "other_model": mod.roll_reason(record, "claude-haiku-4-5", "anthropic"),
         "other_provider": mod.roll_reason(record, "claude-opus-4-7", "openrouter"),
       }
 
-      # Identity change: touch soul.md after record creation.
-      import os, time
+      # A same-content touch must not roll a live session.
+      import os
       soul = mod.AGENT_IDENTITY_PATH / "soul.md"
       os.utime(soul, ns=(soul.stat().st_atime_ns, soul.stat().st_mtime_ns + 1_000_000))
-      checks["identity_changed"] = mod.roll_reason(record, "claude-opus-4-7", "anthropic")
+      checks["same_content_touch"] = mod.roll_reason(record, "claude-opus-4-7", "anthropic")
+      soul.write_text("SOUL CHANGED\\n")
+      checks["identity_changed"], checks["changed_files"] = mod.roll_decision(
+          record, "claude-opus-4-7", "anthropic"
+      )
 
       mod.retire_session_record("sess-1", reason="test")
       checks["after_retire"] = mod.load_session_record("sess-1")
@@ -62,12 +197,47 @@ class TriggerShimSessionTest < ActiveSupport::TestCase
 
     checks = JSON.parse(out)
     assert_equal "pid-abc", checks["loaded_pid"]
+    assert_equal 2, checks["schema_version"]
     assert_equal 50, checks["cumulative_input_tokens"]
+    assert_equal "SOUL FIRST\n".bytesize, checks.dig("soul_fingerprint", "bytes")
+    assert_match(/\A[0-9a-f]{64}\z/, checks.dig("soul_fingerprint", "sha256"))
     assert_nil checks["same_model"]
     assert_equal "model-changed", checks["other_model"]
     assert_equal "provider-changed", checks["other_provider"]
+    assert_nil checks["same_content_touch"]
     assert_equal "identity-changed", checks["identity_changed"]
+    assert_equal [ "soul.md" ], checks["changed_files"]
     assert_nil checks["after_retire"]
+  end
+
+  test "sidecar schema and trigger sequence upgrades are forward compatible" do
+    out = run_shim_python(<<~PY)
+      current_fingerprint = mod.identity_fingerprint()
+      version_one = {
+        "schema_version": 1,
+        "provider": "anthropic",
+        "model": "claude-opus-4-7",
+        "identity_fingerprint": current_fingerprint,
+      }
+      future = {**version_one, "schema_version": 99}
+      malformed = {**version_one, "schema_version": "future"}
+      print(json.dumps({
+        "version_one_roll": mod.roll_reason(version_one, "claude-opus-4-7", "anthropic"),
+        "future_roll": mod.roll_reason(future, "claude-opus-4-7", "anthropic"),
+        "malformed_roll": mod.roll_reason(malformed, "claude-opus-4-7", "anthropic"),
+        "missing_sequence": mod.next_trigger_sequence(version_one),
+        "malformed_sequence": mod.next_trigger_sequence({"trigger_sequence": "unknown"}),
+        "existing_sequence": mod.next_trigger_sequence({"trigger_sequence": 7}),
+      }))
+    PY
+
+    result = JSON.parse(out)
+    assert_nil result["version_one_roll"]
+    assert_equal "sidecar-schema-unsupported", result["future_roll"]
+    assert_equal "sidecar-schema-unsupported", result["malformed_roll"]
+    assert_equal 1, result["missing_sequence"]
+    assert_equal 1, result["malformed_sequence"]
+    assert_equal 8, result["existing_sequence"]
   end
 
   test "usage_since handles cumulative counter resets" do
@@ -105,6 +275,35 @@ class TriggerShimSessionTest < ActiveSupport::TestCase
     assert_not_includes args, "--dangerously-bypass-approvals-and-sandbox"
   end
 
+  test "non-persistent triggers use JSON output and record a legacy fresh lifecycle" do
+    out = run_shim_python(<<~PY, fake_chaos: :echo_resumed_pid)
+      captured = {}
+      original_run_chaos = mod.run_chaos
+      def capture_run(model, timeout_secs, prompt_text, json_output, resume_id=None, provider=None):
+          captured["json_output"] = json_output
+          return original_run_chaos(
+              model, timeout_secs, prompt_text, json_output,
+              resume_id=resume_id, provider=provider
+          )
+      mod.run_chaos = capture_run
+      response, code = mod.legacy_trigger(
+          "legacy-session", "REQUEST FULL", "claude-opus-4-7", 30
+      )
+      print(json.dumps({"response": response, "code": code, "captured": captured}))
+    PY
+
+    result = JSON.parse(out)
+    response = result["response"]
+    assert_equal 200, result["code"]
+    assert_equal true, result.dig("captured", "json_output")
+    assert_equal "legacy_fresh", response.dig("telemetry", "session", "outcome")
+    assert_equal false, response.dig("telemetry", "session", "persistent_requested")
+    assert_equal false, response.dig("telemetry", "session", "mapping_found")
+    assert_equal "full", response.dig("telemetry", "prompt", "mode")
+    assert_equal 120, response.dig("telemetry", "usage", "input_tokens")
+    assert response["chaos_session_id"].present?
+  end
+
   test "first persistent trigger goes fresh, second resumes the mapped session" do
     out = run_shim_python(<<~PY, fake_chaos: :echo_resumed_pid)
       first, code1 = mod.persistent_trigger("sess-2", "REQUEST FULL", None, "claude-opus-4-7", 30)
@@ -120,12 +319,53 @@ class TriggerShimSessionTest < ActiveSupport::TestCase
     assert first["chaos_session_id"].present?
     assert_includes first["full_invocation_text"], "SOUL FIRST", "fresh turn must carry identity"
     assert_includes first["full_invocation_text"], "REQUEST FULL"
+    assert_equal 1, first.dig("telemetry", "schema_version")
+    assert_equal "fake-chaos 0.0.1", first.dig("telemetry", "runtime", "chaos_version")
+    assert_equal "anthropic", first.dig("telemetry", "runtime", "provider")
+    assert_equal "claude-opus-4-7", first.dig("telemetry", "runtime", "model")
+    assert_equal "1h", first.dig("telemetry", "runtime", "cache_ttl")
+    assert_equal "fresh", first.dig("telemetry", "session", "outcome")
+    assert_equal "full", first.dig("telemetry", "prompt", "mode")
+    assert_operator first.dig("telemetry", "prompt", "full_prompt_bytes"), :>, 0
+    assert_equal 120, first.dig("telemetry", "usage", "input_tokens")
+    assert_equal 30, first.dig("telemetry", "usage", "cache_read_input_tokens")
+    assert_equal 1, first.dig("telemetry", "usage", "provider_request_count")
+    assert_equal "process_cumulative", first.dig("telemetry", "session_usage", "scope")
 
     assert_equal 200, result["code2"]
     assert_equal true, second["session_resumed"], "second trigger should resume"
     assert_equal first["chaos_session_id"], second["chaos_session_id"]
     assert_equal "DELTA ONLY", second["full_invocation_text"], "resumed turn sends the delta, unwrapped"
-    assert_equal first["usage"], second["usage"], "cumulative Chaos counters must be converted to a per-trigger delta"
+    assert_equal first["usage"], second["usage"], "Chaos reports each invocation directly"
+    assert_equal "resumed", second.dig("telemetry", "session", "outcome")
+    assert_equal true, second.dig("telemetry", "session", "mapping_found")
+    assert_equal true, second.dig("telemetry", "session", "resume_attempted")
+    assert_equal 2, second.dig("telemetry", "session", "trigger_sequence")
+    assert_equal "delta", second.dig("telemetry", "prompt", "mode")
+    assert_equal "DELTA ONLY".bytesize, second.dig("telemetry", "prompt", "selected_prompt_bytes")
+    assert_nil second.dig("telemetry", "prompt", "full_prompt_bytes")
+    assert_equal({}, second.dig("telemetry", "prompt", "components"))
+  end
+
+  test "successful resume does not rebuild the full prompt or reread journals" do
+    out = run_shim_python(<<~PY, fake_chaos: :echo_resumed_pid)
+      first, _ = mod.persistent_trigger("sess-no-reread", "REQUEST ONE", None, "claude-opus-4-7", 30)
+
+      def fail_if_journals_are_read():
+          raise AssertionError("successful resume rebuilt memory context")
+      mod.memory_context = fail_if_journals_are_read
+
+      second, code = mod.persistent_trigger(
+          "sess-no-reread", "REQUEST TWO", "DELTA ONLY", "claude-opus-4-7", 30
+      )
+      print(json.dumps({"first": first, "second": second, "code": code}))
+    PY
+
+    result = JSON.parse(out)
+    assert_equal 200, result["code"]
+    assert_equal true, result.dig("second", "session_resumed")
+    assert_equal "DELTA ONLY", result.dig("second", "full_invocation_text")
+    assert_nil result.dig("second", "telemetry", "prompt", "full_prompt_bytes")
   end
 
   test "stale resume falls back to one fresh full-identity retry" do
@@ -144,6 +384,10 @@ class TriggerShimSessionTest < ActiveSupport::TestCase
     assert_equal false, second["session_resumed"]
     assert_equal true, second["fresh_fallback"]
     assert_equal "resume-failed", second["session_roll_reason"]
+    assert_equal "fresh_fallback", second.dig("telemetry", "session", "outcome")
+    assert_equal "trigger", second.dig("telemetry", "usage", "scope")
+    assert_equal 240, second.dig("telemetry", "usage", "input_tokens")
+    assert_equal 2, second.dig("telemetry", "usage", "provider_request_count")
     assert_includes second["full_invocation_text"], "SOUL FIRST", "fallback must re-inject identity"
     assert_includes second["full_invocation_text"], "REQUEST TWO"
     assert_not_includes second["full_invocation_text"], "DELTA ONLY", "the fallback retry must use the full prompt"
@@ -151,9 +395,9 @@ class TriggerShimSessionTest < ActiveSupport::TestCase
 
   test "resume timeout retires the ambiguous session mapping" do
     out = run_shim_python(<<~PY)
-      events = {"process_id": "pid-timeout", "input_tokens": 50, "cached_input_tokens": 0, "output_tokens": 5}
-      usage = mod.usage_since(None, events)
-      mod.save_session_record("sess-timeout", "claude-opus-4-7", events, usage)
+      events = mod.parse_events('{"type":"process.started","process_id":"pid-timeout"}\\n' +
+        '{"type":"turn.completed","usage":{"input_tokens":50,"cached_input_tokens":0,"output_tokens":5}}')
+      mod.save_session_record("sess-timeout", "claude-opus-4-7", events)
 
       def time_out(*args, **kwargs):
           raise mod.subprocess.TimeoutExpired(cmd="chaos", timeout=30)
@@ -172,6 +416,52 @@ class TriggerShimSessionTest < ActiveSupport::TestCase
     result = JSON.parse(out)
     assert_equal 504, result["code"]
     assert_equal "timeout", result.dig("response", "status")
+    assert_equal "resume_timeout", result.dig("response", "telemetry", "session", "outcome")
+    assert_equal "incomplete", result.dig("response", "telemetry", "chaos_telemetry_status")
+    assert_nil result["record"]
+  end
+
+  test "timeout salvages partial versioned usage and marks it incomplete" do
+    out = run_shim_python(<<~PY)
+      initial = mod.parse_events(
+        '{"type":"process.started","process_id":"pid-partial"}\\n' +
+        '{"type":"turn.completed","usage":{"input_tokens":50,"cached_input_tokens":0,"output_tokens":5}}'
+      )
+      mod.save_session_record("sess-partial", "claude-opus-4-7", initial)
+      partial = "\\n".join([
+        '{"type":"process.started","process_id":"pid-partial"}',
+        '{"type":"invocation.completed","telemetry_schema_version":1,"usage":' +
+          '{"scope":"invocation","input_tokens":90,"uncached_input_tokens":10,' +
+          '"cache_creation_input_tokens":20,"cache_read_input_tokens":60,' +
+          '"output_tokens":8,"provider_request_count":2}}',
+      ])
+
+      def time_out(*args, **kwargs):
+          raise mod.subprocess.TimeoutExpired(
+              cmd="chaos", timeout=30, output=partial, stderr="partial stderr"
+          )
+      mod.run_chaos = time_out
+
+      response, code = mod.persistent_trigger(
+          "sess-partial", "REQUEST FULL", "DELTA ONLY", "claude-opus-4-7", 30
+      )
+      print(json.dumps({
+          "response": response,
+          "code": code,
+          "record": mod.load_session_record("sess-partial"),
+      }))
+    PY
+
+    result = JSON.parse(out)
+    response = result["response"]
+    assert_equal 504, result["code"]
+    assert_equal false, response["session_resumed"]
+    assert_equal 90, response.dig("telemetry", "usage", "input_tokens")
+    assert_equal 20, response.dig("telemetry", "usage", "cache_creation_input_tokens")
+    assert_equal false, response.dig("telemetry", "usage", "complete")
+    assert_equal false, response.dig("usage", "complete")
+    assert_equal "partial stderr", response["stderr"]
+    assert_equal "incomplete", response.dig("telemetry", "chaos_telemetry_status")
     assert_nil result["record"]
   end
 
@@ -186,6 +476,9 @@ class TriggerShimSessionTest < ActiveSupport::TestCase
     second = result["second"]
     assert_equal false, second["session_resumed"]
     assert_equal "model-changed", second["session_roll_reason"]
+    assert_equal "rolled", second.dig("telemetry", "session", "outcome")
+    assert_equal true, second.dig("telemetry", "session", "mapping_found")
+    assert_equal false, second.dig("telemetry", "session", "resume_attempted")
     assert_includes second["full_invocation_text"], "SOUL FIRST"
     assert_not_equal result.dig("first", "chaos_session_id"), second["chaos_session_id"]
   end
@@ -222,7 +515,8 @@ class TriggerShimSessionTest < ActiveSupport::TestCase
         "AGENT_IDENTITY_PATH" => identity.to_s,
         "AGENT_REPO_PATH" => dir.to_s,
         "CHAOS_HOME" => chaos_home.to_s,
-        "CHAOS_BIN" => chaos_bin.to_s
+        "CHAOS_BIN" => chaos_bin.to_s,
+        "CHAOS_ANTHROPIC_CACHE_TTL" => "1h"
       }
       stdout, stderr, status = Open3.capture3(env, "python3", "-c", command)
       assert status.success?, stderr
@@ -251,15 +545,27 @@ class TriggerShimSessionTest < ActiveSupport::TestCase
       if pid is None:
           pid = f"pid-{uuid.uuid4()}"
 
-      resumed = "resume" in args and #{honour_resume ? 'True' : 'False'}
-      multiplier = 2 if resumed else 1
       print(json.dumps({"type": "process.started", "process_id": pid}))
       print(json.dumps({"type": "item.completed", "item": {"id": "1", "type": "agent_message", "text": "fake reply"}}))
-      print(json.dumps({"type": "turn.completed", "usage": {
-          "input_tokens": 120 * multiplier,
-          "cached_input_tokens": 30 * multiplier,
-          "output_tokens": 9 * multiplier,
-      }}))
+      print(json.dumps({
+        "type": "turn.completed",
+        "telemetry_schema_version": 1,
+        "usage": {
+          "scope": "invocation",
+          "input_tokens": 120,
+          "uncached_input_tokens": 80,
+          "cache_creation_input_tokens": 10,
+          "cache_read_input_tokens": 30,
+          "output_tokens": 9,
+          "provider_request_count": 1,
+        },
+        "session_usage": {
+          "scope": "process_cumulative",
+          "input_tokens": 120,
+          "output_tokens": 9,
+          "provider_request_count": 1,
+        },
+      }))
     PYTHON
   end
 

--- a/test/models/agent_runtime_interaction_test.rb
+++ b/test/models/agent_runtime_interaction_test.rb
@@ -153,4 +153,308 @@ class AgentRuntimeInteractionTest < ActiveSupport::TestCase
     assert_nil interaction.output_tokens
   end
 
+  test "record_result! persists versioned invocation telemetry without conflating unknown and zero" do
+    agent = agents(:research_assistant)
+    chat = agent.account.chats.create!(model_id: "openrouter/auto", title: "Runtime telemetry")
+
+    AgentRuntimeInteraction.record_trigger!(
+      agent: agent,
+      chat: chat,
+      trigger_kind: "conversation",
+      conversation_id: chat.to_param,
+      requested_by: "test",
+      session_id: "session-observed",
+      endpoint_url: "https://agent.example.com",
+      request_text: "Please respond"
+    ) do
+      {
+        status: 200,
+        body: {
+          "status" => "ok",
+          "telemetry" => {
+            "schema_version" => 1,
+            "chaos_telemetry_status" => "detailed",
+            "runtime" => {
+              "chaos_version" => "chaos 1.2.3 (abc1234)",
+              "provider" => "anthropic",
+              "model" => "claude-fable-5",
+              "cache_ttl" => "1h"
+            },
+            "session" => {
+              "persistent_requested" => true,
+              "mapping_found" => true,
+              "resume_attempted" => true,
+              "outcome" => "resumed",
+              "roll_reason" => nil,
+              "changed_identity_files" => [],
+              "prior_chaos_process_id" => "chaos-1",
+              "chaos_process_id" => "chaos-1",
+              "trigger_sequence" => 3,
+              "session_age_seconds" => 120
+            },
+            "prompt" => {
+              "mode" => "delta",
+              "full_prompt_bytes" => 90_000,
+              "delta_prompt_bytes" => 3_000,
+              "selected_prompt_bytes" => 3_000,
+              "components" => {}
+            },
+            "usage" => {
+              "scope" => "invocation",
+              "input_tokens" => 1_500,
+              "uncached_input_tokens" => 0,
+              "cache_creation_input_tokens" => 100,
+              "cache_read_input_tokens" => 1_400,
+              "output_tokens" => 50,
+              "reasoning_output_tokens" => nil,
+              "provider_request_count" => 2
+            }
+          }
+        }
+      }
+    end
+
+    interaction = AgentRuntimeInteraction.last
+    assert_equal 1, interaction.telemetry_schema_version
+    assert_equal "detailed", interaction.chaos_telemetry_status
+    assert_equal "chaos 1.2.3 (abc1234)", interaction.chaos_version
+    assert_equal "anthropic", interaction.provider
+    assert_equal "claude-fable-5", interaction.model
+    assert_equal "1h", interaction.cache_ttl
+    assert interaction.persistent_session_requested
+    assert interaction.session_mapping_found
+    assert interaction.resume_attempted
+    assert_equal "resumed", interaction.session_outcome
+    assert_equal [], interaction.changed_identity_files
+    assert_equal "chaos-1", interaction.chaos_session_id
+    assert_equal "delta", interaction.prompt_mode
+    assert_equal 3_000, interaction.selected_prompt_bytes
+    assert_equal "invocation", interaction.usage_scope
+    assert_equal 0, interaction.uncached_input_tokens
+    assert_equal 100, interaction.cache_creation_input_tokens
+    assert_equal 1_400, interaction.cache_read_input_tokens
+    assert_equal 1_400, interaction.cached_input_tokens
+    assert_nil interaction.reasoning_output_tokens
+    assert_equal 2, interaction.provider_request_count
+    assert interaction.usage_complete
+  end
+
+  test "old runtime response does not fabricate detailed telemetry" do
+    interaction = AgentRuntimeInteraction.create!(
+      agent: agents(:research_assistant),
+      trigger_kind: "wake",
+      session_id: "old-runtime",
+      started_at: Time.current
+    )
+
+    interaction.record_result!(
+      status: 200,
+      body: {
+        "status" => "ok",
+        "usage" => {
+          "input_tokens" => 100,
+          "cached_input_tokens" => 40,
+          "output_tokens" => 20
+        }
+      }
+    )
+
+    assert_equal 100, interaction.input_tokens
+    assert_equal 40, interaction.cached_input_tokens
+    assert_nil interaction.telemetry_schema_version
+    assert_nil interaction.cache_creation_input_tokens
+    assert_nil interaction.cache_read_input_tokens
+    assert_nil interaction.provider_request_count
+    assert_nil interaction.usage_complete
+  end
+
+  test "telemetry envelope without detailed usage does not upgrade coarse fallback usage" do
+    interaction = AgentRuntimeInteraction.create!(
+      agent: agents(:research_assistant),
+      trigger_kind: "wake",
+      session_id: "mixed-runtime",
+      started_at: Time.current
+    )
+
+    interaction.record_result!(
+      status: 200,
+      body: {
+        "status" => "ok",
+        "telemetry" => {
+          "schema_version" => 1,
+          "runtime" => { "provider" => "anthropic" },
+          "session" => { "outcome" => "fresh" }
+        },
+        "usage" => {
+          "input_tokens" => 100,
+          "cached_input_tokens" => 40,
+          "output_tokens" => 20
+        }
+      }
+    )
+
+    assert_equal 1, interaction.telemetry_schema_version
+    assert_equal "anthropic", interaction.provider
+    assert_equal 40, interaction.cached_input_tokens
+    assert_nil interaction.cache_read_input_tokens
+    assert_nil interaction.cache_creation_input_tokens
+    assert_nil interaction.usage_scope
+    assert_nil interaction.usage_complete
+  end
+
+  test "unversioned additive usage remains coarse because invocation scope is unknown" do
+    interaction = AgentRuntimeInteraction.create!(
+      agent: agents(:research_assistant),
+      trigger_kind: "memory_aggregation_daily",
+      session_id: "legacy-json",
+      started_at: Time.current
+    )
+
+    interaction.record_result!(
+      status: 200,
+      body: {
+        "status" => "ok",
+        "usage" => {
+          "input_tokens" => 100,
+          "cache_creation_input_tokens" => 20,
+          "cached_input_tokens" => 70,
+          "output_tokens" => 5,
+          "reasoning_output_tokens" => 1,
+          "provider_request_count" => 2
+        }
+      }
+    )
+
+    assert_nil interaction.uncached_input_tokens
+    assert_nil interaction.cache_creation_input_tokens
+    assert_nil interaction.cache_read_input_tokens
+    assert_equal 70, interaction.cached_input_tokens
+    assert_nil interaction.reasoning_output_tokens
+    assert_nil interaction.provider_request_count
+    assert_nil interaction.usage_complete
+  end
+
+  test "unsupported Chaos telemetry remains explicitly diagnosable" do
+    interaction = AgentRuntimeInteraction.create!(
+      agent: agents(:research_assistant),
+      trigger_kind: "wake",
+      session_id: "unsupported-runtime",
+      started_at: Time.current
+    )
+
+    interaction.record_result!(
+      status: 200,
+      body: {
+        "status" => "ok",
+        "telemetry" => {
+          "schema_version" => 1,
+          "chaos_telemetry_status" => "unsupported",
+          "unsupported_chaos_telemetry_schema_version" => 99,
+          "usage" => nil
+        }
+      }
+    )
+
+    assert_equal "unsupported", interaction.chaos_telemetry_status
+    assert_equal 99, interaction.unsupported_chaos_telemetry_schema_version
+    assert_nil interaction.input_tokens
+    assert_nil interaction.cache_creation_input_tokens
+    assert_nil interaction.usage_complete
+  end
+
+  test "versioned usage derives uncached input only when all categories are known" do
+    interaction = AgentRuntimeInteraction.create!(
+      agent: agents(:research_assistant),
+      trigger_kind: "wake",
+      session_id: "derived-input",
+      started_at: Time.current
+    )
+
+    interaction.record_result!(
+      status: 200,
+      body: {
+        "status" => "ok",
+        "telemetry" => {
+          "schema_version" => 1,
+          "usage" => {
+            "scope" => "invocation",
+            "input_tokens" => 100,
+            "cache_creation_input_tokens" => 20,
+            "cache_read_input_tokens" => 70,
+            "output_tokens" => 5
+          }
+        }
+      }
+    )
+
+    assert_equal 10, interaction.uncached_input_tokens
+
+    interaction.record_result!(
+      status: 200,
+      body: {
+        "status" => "ok",
+        "telemetry" => {
+          "schema_version" => 1,
+          "usage" => {
+            "scope" => "invocation",
+            "input_tokens" => 100,
+            "cache_creation_input_tokens" => nil,
+            "cache_read_input_tokens" => 70,
+            "output_tokens" => 5
+          }
+        }
+      }
+    )
+
+    assert_nil interaction.uncached_input_tokens
+  end
+
+  test "token and lifecycle helpers preserve unknown values" do
+    interaction = AgentRuntimeInteraction.new(
+      session_outcome: "resumed",
+      prompt_mode: "delta",
+      input_tokens: 200,
+      cache_creation_input_tokens: 20,
+      cache_read_input_tokens: 150,
+      output_tokens: 10,
+      provider_request_count: 3
+    )
+
+    assert interaction.resumed_session?
+    assert_not interaction.fresh_session?
+    assert_not interaction.cold_start?
+    assert_in_delta 0.75, interaction.cache_read_ratio
+    assert_in_delta 0.10, interaction.cache_creation_ratio
+    assert_equal 3, interaction.provider_requests_per_trigger
+    assert_equal(
+      {
+        input: 200,
+        uncached_input: nil,
+        cache_creation_input: 20,
+        cache_read_input: 150,
+        output: 10,
+        reasoning_output: nil
+      },
+      interaction.token_breakdown
+    )
+
+    interaction.assign_attributes(session_outcome: "rolled", prompt_mode: "full", input_tokens: nil)
+    assert interaction.cold_start?
+    assert_nil interaction.cache_read_ratio
+  end
+
+  test "observability migration uses query-safe numeric and structured column types" do
+    columns = AgentRuntimeInteraction.columns_hash
+
+    assert_equal :integer, columns.fetch("telemetry_schema_version").type
+    assert_equal :string, columns.fetch("chaos_telemetry_status").type
+    assert_equal :integer, columns.fetch("unsupported_chaos_telemetry_schema_version").type
+    assert_equal "bigint", columns.fetch("full_prompt_bytes").sql_type
+    assert_equal :jsonb, columns.fetch("changed_identity_files").type
+    assert_equal :jsonb, columns.fetch("prompt_component_bytes").type
+    assert_equal "bigint", columns.fetch("cache_creation_input_tokens").sql_type
+    assert_equal :integer, columns.fetch("provider_request_count").type
+    assert_equal :boolean, columns.fetch("usage_complete").type
+  end
+
 end

--- a/test/models/agent_runtime_interaction_test.rb
+++ b/test/models/agent_runtime_interaction_test.rb
@@ -268,6 +268,43 @@ class AgentRuntimeInteractionTest < ActiveSupport::TestCase
     assert_nil interaction.usage_complete
   end
 
+  test "record_result! persists trigger-local usage aggregated across fallback invocations" do
+    interaction = AgentRuntimeInteraction.create!(
+      agent: agents(:research_assistant),
+      trigger_kind: "conversation",
+      session_id: "fallback-trigger",
+      started_at: Time.current
+    )
+
+    interaction.record_result!(
+      status: 200,
+      body: {
+        "status" => "ok",
+        "telemetry" => {
+          "schema_version" => 1,
+          "chaos_telemetry_status" => "detailed",
+          "usage" => {
+            "scope" => "trigger",
+            "complete" => true,
+            "input_tokens" => 2_000,
+            "uncached_input_tokens" => 100,
+            "cache_creation_input_tokens" => 300,
+            "cache_read_input_tokens" => 1_600,
+            "output_tokens" => 80,
+            "provider_request_count" => 4
+          }
+        }
+      }
+    )
+
+    assert_equal "trigger", interaction.usage_scope
+    assert interaction.usage_complete
+    assert_equal 2_000, interaction.input_tokens
+    assert_equal 300, interaction.cache_creation_input_tokens
+    assert_equal 1_600, interaction.cache_read_input_tokens
+    assert_equal 4, interaction.provider_request_count
+  end
+
   test "telemetry envelope without detailed usage does not upgrade coarse fallback usage" do
     interaction = AgentRuntimeInteraction.create!(
       agent: agents(:research_assistant),

--- a/test/services/agent_runtime_usage_report_test.rb
+++ b/test/services/agent_runtime_usage_report_test.rb
@@ -1,0 +1,296 @@
+require "test_helper"
+
+class AgentRuntimeUsageReportTest < ActiveSupport::TestCase
+
+  setup do
+    @agent = agents(:research_assistant)
+    @from = Time.utc(2026, 7, 18, 12)
+    @to = Time.utc(2026, 7, 18, 14)
+  end
+
+  test "groups logical sessions while preserving chaos process transitions and invocation totals" do
+    create_interaction!(
+      started_at: @from + 10.minutes,
+      session_id: "conversation-1",
+      chaos_session_id: "chaos-a",
+      session_outcome: "fresh",
+      provider_request_count: 1,
+      uncached_input_tokens: 100,
+      cache_creation_input_tokens: 900,
+      cache_read_input_tokens: 0,
+      output_tokens: 50
+    )
+    create_interaction!(
+      started_at: @from + 20.minutes,
+      session_id: "conversation-1",
+      prior_chaos_session_id: "chaos-a",
+      chaos_session_id: "chaos-b",
+      session_outcome: "rolled",
+      session_roll_reason: "model-changed",
+      provider_request_count: 3,
+      uncached_input_tokens: 10,
+      cache_creation_input_tokens: 20,
+      cache_read_input_tokens: 970,
+      output_tokens: 25
+    )
+
+    report = AgentRuntimeUsageReport.new(agent: @agent, from: @from, to: @to).call
+
+    assert_equal "UTC", report.dig(:window, :timezone)
+    assert_equal 2, report.dig(:summary, :interactions)
+    assert_equal 1, report.dig(:summary, :logical_sessions)
+    assert_equal 2, report.dig(:summary, :chaos_processes)
+    assert_equal 4, report.dig(:summary, :provider_requests)
+    assert_equal 920, report.dig(:summary, :tokens, :cache_creation_input_tokens)
+    assert_equal 970, report.dig(:summary, :tokens, :cache_read_input_tokens)
+    assert_equal({ "conversation" => 2 }, report.dig(:groups, :trigger_kinds))
+    assert_equal({ "fresh" => 1, "rolled" => 1 }, report.dig(:groups, :session_outcomes))
+
+    session = report.fetch(:sessions).first
+    assert_equal "conversation-1", session.fetch(:session_id)
+    assert_equal [ "chaos-a", "chaos-b" ], session.fetch(:chaos_process_ids)
+    assert_equal 2, session.fetch(:interaction_count)
+    assert_equal({ "model-changed" => 1 }, session.fetch(:roll_reasons))
+    assert_equal 2, session.fetch(:interactions).size
+    assert_equal "complete", session.fetch(:telemetry_state)
+  end
+
+  test "does not treat old coarse usage as versioned invocation usage" do
+    create_interaction!(
+      started_at: @from + 10.minutes,
+      session_id: "old-runtime",
+      telemetry_schema_version: nil,
+      usage_scope: nil,
+      usage_complete: nil,
+      input_tokens: 100,
+      output_tokens: 0
+    )
+
+    report = AgentRuntimeUsageReport.new(agent: @agent, from: @from, to: @to).call
+
+    assert_nil report.dig(:summary, :tokens, :cache_creation_input_tokens)
+    assert_nil report.dig(:summary, :tokens, :output_tokens)
+    assert_equal 1, report.dig(:summary, :token_unknown_rows, :output_tokens)
+    assert_equal 0, report.dig(:summary, :incomplete_usage_rows)
+    assert_equal 1, report.dig(:summary, :unavailable_usage_rows)
+    assert_equal 0, report.dig(:summary, :complete_usage_rows)
+
+    interaction = report.dig(:sessions, 0, :interactions, 0)
+    assert_equal "unavailable", interaction.fetch(:telemetry_state)
+    assert_match(/runtime image did not report/, interaction.fetch(:telemetry_state_reason))
+  end
+
+  test "keeps reported zero distinct from unknown" do
+    create_interaction!(
+      started_at: @from + 10.minutes,
+      session_id: "reported-zero",
+      provider_request_count: 0,
+      input_tokens: 0,
+      uncached_input_tokens: 0,
+      cache_creation_input_tokens: 0,
+      cache_read_input_tokens: 0,
+      output_tokens: 0,
+      reasoning_output_tokens: nil
+    )
+
+    report = AgentRuntimeUsageReport.new(agent: @agent, from: @from, to: @to).call
+
+    assert_equal 0, report.dig(:summary, :provider_requests)
+    assert_equal 0, report.dig(:summary, :tokens, :cache_creation_input_tokens)
+    assert_equal 0, report.dig(:summary, :tokens, :output_tokens)
+    assert_nil report.dig(:summary, :tokens, :reasoning_output_tokens)
+    assert_equal 0, report.dig(:summary, :token_unknown_rows, :output_tokens)
+    assert_equal 1, report.dig(:summary, :token_unknown_rows, :reasoning_output_tokens)
+  end
+
+  test "uses exact UTC range boundaries" do
+    create_interaction!(started_at: @from - 1.second, session_id: "before")
+    create_interaction!(started_at: @from, session_id: "inside-start")
+    create_interaction!(started_at: @to, session_id: "inside-end")
+    create_interaction!(started_at: @to + 1.second, session_id: "after")
+
+    report = AgentRuntimeUsageReport.new(agent: @agent, from: @from, to: @to).call
+
+    assert_equal 2, report.dig(:summary, :interactions)
+    assert_equal [ "inside-end", "inside-start" ], report.fetch(:sessions).map { |session| session[:session_id] }
+  end
+
+  test "normalizes an explicitly offset window to UTC" do
+    report = AgentRuntimeUsageReport.new(
+      agent: @agent,
+      from: Time.iso8601("2026-07-18T14:00:00+02:00"),
+      to: Time.iso8601("2026-07-18T16:00:00+02:00")
+    ).call
+
+    assert_equal "2026-07-18T12:00:00Z", report.dig(:window, :from)
+    assert_equal "2026-07-18T14:00:00Z", report.dig(:window, :to)
+    assert_equal "UTC", report.dig(:window, :timezone)
+  end
+
+  test "filters dimensions and keeps filter options for the UTC window" do
+    create_interaction!(
+      started_at: @from + 10.minutes,
+      session_id: "wake-1",
+      trigger_kind: "wake",
+      provider: "anthropic",
+      model: "claude-fable-5",
+      session_outcome: "resumed"
+    )
+    create_interaction!(
+      started_at: @from + 20.minutes,
+      session_id: "chat-1",
+      trigger_kind: "conversation",
+      provider: "openai",
+      model: "gpt-5.5",
+      session_outcome: "fresh"
+    )
+
+    report = AgentRuntimeUsageReport.new(
+      agent: @agent,
+      from: @from,
+      to: @to,
+      filters: { trigger_kind: "wake", provider: "anthropic" }
+    ).call
+
+    assert_equal 1, report.dig(:summary, :interactions)
+    assert_equal "wake-1", report.dig(:sessions, 0, :session_id)
+    assert_equal({ trigger_kind: "wake", provider: "anthropic" }, report.fetch(:filters))
+    assert_equal [ "conversation", "wake" ], report.dig(:filter_options, :trigger_kind)
+    assert_equal [ "anthropic", "openai" ], report.dig(:filter_options, :provider)
+  end
+
+  test "reports session duration lifecycle decisions prompt sizes and runtime fields" do
+    interaction = create_interaction!(
+      started_at: @from + 10.minutes,
+      finished_at: @from + 11.minutes,
+      duration_ms: 60_000,
+      session_id: "timeline-1",
+      persistent_session_requested: true,
+      session_mapping_found: true,
+      resume_attempted: true,
+      session_outcome: "resumed",
+      prior_chaos_session_id: "chaos-a",
+      chaos_session_id: "chaos-a",
+      session_trigger_sequence: 4,
+      session_age_seconds: 300,
+      prompt_mode: "delta",
+      full_prompt_bytes: 90_000,
+      delta_prompt_bytes: 3_000,
+      selected_prompt_bytes: 3_000,
+      prompt_component_bytes: { "request" => 2_000 },
+      chaos_version: "chaos 0.1.0 (abc1234)",
+      provider: "anthropic",
+      model: "claude-fable-5",
+      cache_ttl: "1h",
+      provider_request_count: 2,
+      uncached_input_tokens: 10,
+      cache_creation_input_tokens: 20,
+      cache_read_input_tokens: 970,
+      output_tokens: 30
+    )
+
+    report = AgentRuntimeUsageReport.new(agent: @agent, from: @from, to: @to).call
+    session = report.fetch(:sessions).first
+    row = session.fetch(:interactions).first
+
+    assert_equal 60_000, session.fetch(:active_duration_ms)
+    assert_equal 3_000, session.fetch(:selected_prompt_bytes)
+    assert_equal interaction.to_param, row.fetch(:id)
+    assert_equal true, row.fetch(:persistent_session_requested)
+    assert_equal true, row.fetch(:session_mapping_found)
+    assert_equal true, row.fetch(:resume_attempted)
+    assert_equal 90_000, row.fetch(:full_prompt_bytes)
+    assert_equal "chaos 0.1.0 (abc1234)", row.fetch(:chaos_version)
+    assert_equal "versioned invocation-local telemetry complete", row.fetch(:telemetry_state_reason)
+  end
+
+  test "excludes process cumulative usage and marks unsupported telemetry" do
+    create_interaction!(
+      started_at: @from + 10.minutes,
+      session_id: "process-cumulative",
+      telemetry_schema_version: 1,
+      usage_scope: "process_cumulative",
+      usage_complete: true,
+      cache_read_input_tokens: 50_000,
+      provider_request_count: 20
+    )
+    create_interaction!(
+      started_at: @from + 20.minutes,
+      session_id: "future-schema",
+      telemetry_schema_version: 2,
+      usage_scope: "invocation",
+      usage_complete: true,
+      cache_read_input_tokens: 75_000,
+      provider_request_count: 30
+    )
+
+    report = AgentRuntimeUsageReport.new(agent: @agent, from: @from, to: @to).call
+
+    assert_nil report.dig(:summary, :tokens, :cache_read_input_tokens)
+    assert_nil report.dig(:summary, :provider_requests)
+    assert_equal 2, report.dig(:summary, :token_unknown_rows, :cache_read_input_tokens)
+    assert_equal 1, report.dig(:summary, :incomplete_usage_rows)
+    assert_equal 1, report.dig(:summary, :unsupported_usage_rows)
+
+    report.fetch(:sessions).each do |session|
+      interaction = session.fetch(:interactions).first
+      assert_nil interaction.fetch(:provider_request_count)
+      assert_nil interaction.dig(:tokens, :cache_read_input_tokens)
+    end
+  end
+
+  test "distinguishes legacy and unsupported Chaos telemetry" do
+    create_interaction!(
+      started_at: @from + 10.minutes,
+      session_id: "legacy-chaos",
+      chaos_telemetry_status: "legacy",
+      usage_scope: nil,
+      usage_complete: nil
+    )
+    create_interaction!(
+      started_at: @from + 20.minutes,
+      session_id: "future-chaos",
+      chaos_telemetry_status: "unsupported",
+      unsupported_chaos_telemetry_schema_version: 99,
+      usage_scope: nil,
+      usage_complete: nil
+    )
+
+    report = AgentRuntimeUsageReport.new(agent: @agent, from: @from, to: @to).call
+
+    assert_equal 1, report.dig(:summary, :unavailable_usage_rows)
+    assert_equal 1, report.dig(:summary, :unsupported_usage_rows)
+
+    rows = report.fetch(:sessions).to_h do |session|
+      [ session.fetch(:session_id), session.fetch(:interactions).first ]
+    end
+    assert_equal "unavailable", rows.fetch("legacy-chaos").fetch(:telemetry_state)
+    assert_match(/legacy cumulative/, rows.fetch("legacy-chaos").fetch(:telemetry_state_reason))
+    assert_equal "unsupported", rows.fetch("future-chaos").fetch(:telemetry_state)
+    assert_match(/version 99/, rows.fetch("future-chaos").fetch(:telemetry_state_reason))
+    assert_equal 99, rows.fetch("future-chaos").fetch(:unsupported_chaos_telemetry_schema_version)
+  end
+
+  test "rejects an inverted UTC window" do
+    error = assert_raises(ArgumentError) do
+      AgentRuntimeUsageReport.new(agent: @agent, from: @to, to: @from)
+    end
+
+    assert_match(/UTC report window/, error.message)
+  end
+
+  private
+
+  def create_interaction!(**attributes)
+    @agent.agent_runtime_interactions.create!(
+      {
+        trigger_kind: "conversation",
+        started_at: @from,
+        telemetry_schema_version: 1,
+        usage_scope: "invocation",
+        usage_complete: true
+      }.merge(attributes)
+    )
+  end
+
+end

--- a/test/services/agent_runtime_usage_report_test.rb
+++ b/test/services/agent_runtime_usage_report_test.rb
@@ -103,6 +103,35 @@ class AgentRuntimeUsageReportTest < ActiveSupport::TestCase
     assert_equal 1, report.dig(:summary, :token_unknown_rows, :reasoning_output_tokens)
   end
 
+  test "includes trigger-local totals from a resume fallback with two Chaos invocations" do
+    create_interaction!(
+      started_at: @from + 10.minutes,
+      session_id: "fallback-trigger",
+      usage_scope: "trigger",
+      usage_complete: true,
+      session_outcome: "fresh_fallback",
+      provider_request_count: 4,
+      input_tokens: 2_000,
+      uncached_input_tokens: 100,
+      cache_creation_input_tokens: 300,
+      cache_read_input_tokens: 1_600,
+      output_tokens: 80
+    )
+
+    report = AgentRuntimeUsageReport.new(agent: @agent, from: @from, to: @to).call
+
+    assert_equal 4, report.dig(:summary, :provider_requests)
+    assert_equal 2_000, report.dig(:summary, :tokens, :input_tokens)
+    assert_equal 300, report.dig(:summary, :tokens, :cache_creation_input_tokens)
+    assert_equal 0, report.dig(:summary, :provider_request_unknown_rows)
+    assert_equal 1, report.dig(:summary, :complete_usage_rows)
+
+    interaction = report.dig(:sessions, 0, :interactions, 0)
+    assert_equal "complete", interaction.fetch(:telemetry_state)
+    assert_match(/trigger-local telemetry complete/, interaction.fetch(:telemetry_state_reason))
+    assert_equal 4, interaction.fetch(:provider_request_count)
+  end
+
   test "uses exact UTC range boundaries" do
     create_interaction!(started_at: @from - 1.second, session_id: "before")
     create_interaction!(started_at: @from, session_id: "inside-start")


### PR DESCRIPTION
## Summary

- record versioned, trigger-local Chaos usage with separate ordinary input, cache creation, cache reads, output, and provider request counts
- capture fresh/resume/roll/fallback lifecycle decisions, prompt sizes, runtime identity, and content-hash identity changes in the runtime shim
- persist forward-only telemetry without fabricating historical values
- add UTC-window usage reports and an admin-only logical-session timeline with Chaos process transitions
- pin the hosted runtime image to the instrumented Chaos fork commit while upstream PR #14 is reviewed

## Why

Prompt caching is working during stable resumes, but current rows cannot explain provider cache-write costs, provider call multiplication, or session churn. This instrumentation separates HelixKit interactions, logical sessions, Chaos processes, and provider requests so future cost changes can be chosen from recorded evidence.

## Tests

- `bin/rails test` — 2019 runs, 8759 assertions, 0 failures
- focused observability suite — 52 runs, 380 assertions, 0 failures
- `yarn test:unit --run` — 41 tests passed
- `bin/vite build` — passed
- production-shaped `agent-runtime` Docker build — passed
- built runtime health smoke test — HTTP 200 with pinned Chaos version
- focused RuboCop — passed
- changed Svelte files pass Prettier

Repository-wide Prettier still reports six pre-existing unrelated files.
