### PR TITLE
Add Telegram outbound attachments

### DIFF
--- a/agent-runtime/README.md
+++ b/agent-runtime/README.md
@@ -90,6 +90,7 @@ line two with a literal $4.42 and `backticks`
 HELIXKIT_MESSAGE
 printf 'longer markdown' | helixkit-post-message CHAT_ID
 printf 'generated image' | helixkit-post-message CHAT_ID --attach /tmp/image.png
+printf 'caption' | helixkit-send-telegram daniel --attach /tmp/image.png
 ```
 
 It reads `HELIXKIT_APP_URL` and `HELIXKIT_BEARER_TOKEN` from the environment

--- a/agent-runtime/docs/helixkit-api.md
+++ b/agent-runtime/docs/helixkit-api.md
@@ -254,9 +254,17 @@ Prefer the helper:
 
 ```sh
 printf '%s\n' 'A direct update.' | helixkit-send-telegram daniel
+printf '%s\n' 'A generated image.' |
+  helixkit-send-telegram daniel --attach /tmp/image.png
+helixkit-send-telegram --reply-to "$THREAD_ID" --attach /tmp/image.png
 printf '%s\n' 'Reply in this thread.' |
   helixkit-send-telegram --reply-to "$THREAD_ID"
 ```
+
+`--attach` accepts one local file. Text becomes its Telegram caption and is
+optional; captions are limited to 1,024 characters. Eligible JPEG and PNG files
+up to 10 MB are sent as photos, while other files up to 50 MB are sent as
+documents.
 
 List active subscribers:
 

--- a/agent-runtime/helixkit-send-telegram
+++ b/agent-runtime/helixkit-send-telegram
@@ -5,6 +5,8 @@ Send a direct Telegram message through HelixKit as the current hosted agent.
 Usage:
   helixkit-send-telegram RECIPIENT "message text"
   printf 'message text' | helixkit-send-telegram RECIPIENT
+  printf 'caption' | helixkit-send-telegram RECIPIENT --attach /tmp/image.png
+  helixkit-send-telegram RECIPIENT --attach /tmp/image.png
   helixkit-send-telegram all "message text"
   helixkit-send-telegram --reply-to THREAD_ID "message text"
 
@@ -13,30 +15,31 @@ RECIPIENT matches active Telegram subscribers for this agent by email/name
 Never prints bearer or bot tokens.
 """
 
+import argparse
 import json
+import mimetypes
 import os
+from pathlib import Path
 import sys
 import urllib.error
 import urllib.request
+import uuid
 
 
 def main() -> int:
-    reply_to = None
-    args = sys.argv[1:]
-    if args[:1] in (["-h"], ["--help"]):
-        print(__doc__.strip())
-        print()
-        print("Full HelixKit manual: /usr/local/share/helixkit-agent/helixkit-api.md")
-        return 0
-    if args[:1] == ["--reply-to"]:
-        if len(args) not in (2, 3):
-            print("usage: helixkit-send-telegram --reply-to THREAD_ID [MESSAGE]", file=sys.stderr)
-            return 64
-        reply_to = args[1]
-        args = args[2:]
-    elif len(args) not in (1, 2):
-        print("usage: helixkit-send-telegram RECIPIENT [MESSAGE]", file=sys.stderr)
-        return 64
+    parser = argparse.ArgumentParser(
+        prog="helixkit-send-telegram",
+        description="Send a direct Telegram message and optional attachment through HelixKit.",
+        epilog="Full HelixKit manual: /usr/local/share/helixkit-agent/helixkit-api.md",
+    )
+    parser.add_argument("--reply-to", metavar="THREAD_ID")
+    parser.add_argument("--attach", metavar="PATH")
+    parser.add_argument("recipient", nargs="?")
+    parser.add_argument("message", nargs="?")
+    args = parser.parse_args()
+
+    if not args.reply_to and not args.recipient:
+        parser.error("RECIPIENT is required unless --reply-to is used")
 
     app_url = os.environ.get("HELIXKIT_APP_URL")
     token = os.environ.get("HELIXKIT_BEARER_TOKEN")
@@ -47,33 +50,50 @@ def main() -> int:
         print("HELIXKIT_BEARER_TOKEN is missing", file=sys.stderr)
         return 65
 
-    recipient = args[0] if not reply_to else None
-    text = args[1] if not reply_to and len(args) == 2 else (args[0] if reply_to and args else sys.stdin.read())
+    if args.reply_to:
+        text_argument = args.message if args.message is not None else args.recipient
+        recipient = None
+    else:
+        text_argument = args.message
+        recipient = args.recipient
+
+    text = text_argument if text_argument is not None else sys.stdin.read()
     text = normalize_newlines(text).strip()
-    if not text:
-        print("message text is empty", file=sys.stderr)
+    attachment = Path(args.attach).expanduser() if args.attach else None
+
+    if attachment and not attachment.is_file():
+        print(f"attachment not found: {attachment}", file=sys.stderr)
+        return 66
+    if not text and not attachment:
+        print("message text and attachment are empty", file=sys.stderr)
         return 66
 
     url = f"{app_url.rstrip('/')}/api/v1/telegram_messages"
-    payload = {"text": text}
-    if reply_to:
-        payload["reply_to"] = reply_to
+    fields = {"text": text}
+    if args.reply_to:
+        fields["reply_to"] = args.reply_to
     else:
-        payload["recipient"] = recipient
-    body = json.dumps(payload).encode("utf-8")
+        fields["recipient"] = recipient
+
+    if attachment:
+        body, content_type = multipart_body(fields, attachment)
+    else:
+        body = json.dumps(fields).encode("utf-8")
+        content_type = "application/json"
+
     request = urllib.request.Request(
         url,
         data=body,
         headers={
             "Authorization": f"Bearer {token}",
-            "Content-Type": "application/json",
+            "Content-Type": content_type,
             "Accept": "application/json",
         },
         method="POST",
     )
 
     try:
-        with urllib.request.urlopen(request, timeout=30) as response:
+        with urllib.request.urlopen(request, timeout=120 if attachment else 30) as response:
             payload = response.read().decode("utf-8")
             print(payload)
             return 0 if 200 <= response.status < 300 else 1
@@ -88,6 +108,32 @@ def main() -> int:
 
 def normalize_newlines(content: str) -> str:
     return content.replace("\\r\\n", "\n").replace("\\n", "\n")
+
+
+def multipart_body(fields: dict[str, str], attachment: Path) -> tuple[bytes, str]:
+    boundary = f"helixkit-{uuid.uuid4().hex}"
+    chunks = []
+
+    def add(value: bytes) -> None:
+        chunks.append(value)
+        chunks.append(b"\r\n")
+
+    for name, value in fields.items():
+        add(f"--{boundary}".encode())
+        add(f'Content-Disposition: form-data; name="{name}"'.encode())
+        add(b"")
+        add(value.encode("utf-8"))
+
+    content_type = mimetypes.guess_type(attachment.name)[0] or "application/octet-stream"
+    filename = attachment.name.replace('"', "_")
+    add(f"--{boundary}".encode())
+    add(f'Content-Disposition: form-data; name="media"; filename="{filename}"'.encode("utf-8"))
+    add(f"Content-Type: {content_type}".encode())
+    add(b"")
+    add(attachment.read_bytes())
+
+    chunks.append(f"--{boundary}--\r\n".encode())
+    return b"".join(chunks), f"multipart/form-data; boundary={boundary}"
 
 
 if __name__ == "__main__":

--- a/app/controllers/api/v1/telegram_messages_controller.rb
+++ b/app/controllers/api/v1/telegram_messages_controller.rb
@@ -3,28 +3,47 @@ module Api
     class TelegramMessagesController < BaseController
 
       MAX_MESSAGE_LENGTH = 4_000
+      MAX_CAPTION_LENGTH = 1_024
+      MAX_MEDIA_SIZE = 50.megabytes
+      MAX_PHOTO_SIZE = 10.megabytes
+      PHOTO_CONTENT_TYPES = %w[image/jpeg image/png].freeze
+      PHOTO_FALLBACK_EXCLUSIONS = [ "blocked", "chat not found" ].freeze
+      MEDIA_URL_TTL = 5.minutes
 
       def create
         return render json: { error: "Telegram messaging is only available to agent API keys" }, status: :forbidden unless current_api_agent
         return render json: { error: "Telegram is not configured for this agent" }, status: :unprocessable_entity unless current_api_agent.telegram_configured?
 
         text = params[:text].to_s.strip
-        return render json: { error: "text is required" }, status: :unprocessable_entity if text.blank?
-        return render json: { error: "text is too long (max #{MAX_MESSAGE_LENGTH} characters)" }, status: :unprocessable_entity if text.length > MAX_MESSAGE_LENGTH
+        media = params[:media]
+        return render json: { error: "text or media is required" }, status: :unprocessable_entity if text.blank? && media.blank?
+        return render json: { error: "media must be an uploaded file" }, status: :unprocessable_entity if media.present? && !media.respond_to?(:tempfile)
+
+        maximum_length = media.present? ? MAX_CAPTION_LENGTH : MAX_MESSAGE_LENGTH
+        label = media.present? ? "caption" : "text"
+        return render json: { error: "#{label} is too long (max #{maximum_length} characters)" }, status: :unprocessable_entity if text.length > maximum_length
+        return render json: { error: "media is too large (max 50 MB)" }, status: :unprocessable_entity if media.present? && media.size > MAX_MEDIA_SIZE
 
         subscriptions = target_subscriptions
         return render json: { error: "No matching active Telegram subscribers for this agent" }, status: :not_found if subscriptions.empty?
 
+        content_type = detected_content_type(media) if media.present?
+        media_kind = media_kind_for(media, content_type) if media.present?
         delivered = []
         blocked = []
         failures = []
 
         subscriptions.each do |subscription|
+          outbound_message = nil
+
           begin
-            result = current_api_agent.telegram_send_message(subscription.telegram_chat_id, ERB::Util.html_escape(text))
-            record_outbound_message(subscription, text, result)
+            outbound_message = build_outbound_message(subscription, text, media, media_kind, content_type)
+            result = send_outbound_message(subscription, text, outbound_message)
+            record_outbound_message(outbound_message, result)
             delivered << subscriber_json(subscription)
           rescue TelegramNotifiable::TelegramError => e
+            outbound_message&.destroy!
+
             if e.message.include?("blocked") || e.message.include?("chat not found")
               subscription.mark_blocked!
               blocked << subscriber_json(subscription)
@@ -75,15 +94,111 @@ module Api
         }
       end
 
-      def record_outbound_message(subscription, text, result)
-        telegram_message = result["result"] || {}
-        subscription.telegram_messages.create!(
+      def build_outbound_message(subscription, text, media, media_kind, content_type)
+        message = subscription.telegram_messages.build(
           role: "assistant",
-          text: text,
+          text: text.presence || media_placeholder(media_kind, media.original_filename),
+          caption: text.presence,
+          media_kind: media_kind,
+          media_status: ("ready" if media.present?),
+          media_metadata: (media_metadata(media, content_type) if media.present?),
           sender_name: current_api_agent.name,
+          sent_at: Time.current
+        )
+
+        if media.present?
+          media.tempfile.rewind
+          message.media.attach(
+            io: media.tempfile,
+            filename: media.original_filename,
+            content_type: content_type,
+            identify: false
+          )
+        end
+
+        message.save!
+        message
+      end
+
+      def send_outbound_message(subscription, text, message)
+        escaped_text = ERB::Util.html_escape(text)
+        return current_api_agent.telegram_send_message(subscription.telegram_chat_id, escaped_text) unless message.media.attached?
+
+        media_url = download_url_for(message.media)
+        if message.photo?
+          current_api_agent.telegram_send_photo(subscription.telegram_chat_id, media_url, caption: escaped_text.presence)
+        else
+          current_api_agent.telegram_send_document(subscription.telegram_chat_id, media_url, caption: escaped_text.presence)
+        end
+      rescue TelegramNotifiable::TelegramError => error
+        raise unless message.photo? && retry_photo_as_document?(error)
+
+        message.update!(
+          media_kind: "document",
+          text: text.presence || media_placeholder("document", message.media.filename.to_s)
+        )
+        current_api_agent.telegram_send_document(subscription.telegram_chat_id, media_url, caption: escaped_text.presence)
+      end
+
+      def record_outbound_message(message, result)
+        telegram_message = result["result"] || {}
+        message.update!(
           telegram_message_id: telegram_message["message_id"],
           sent_at: telegram_message["date"] ? Time.zone.at(telegram_message["date"]) : Time.current
         )
+      end
+
+      def media_kind_for(media, content_type)
+        return "photo" if PHOTO_CONTENT_TYPES.include?(content_type) && media.size <= MAX_PHOTO_SIZE
+
+        "document"
+      end
+
+      def detected_content_type(media)
+        media.tempfile.rewind
+        Marcel::MimeType.for(
+          media.tempfile,
+          name: media.original_filename,
+          declared_type: media.content_type
+        )
+      ensure
+        media.tempfile.rewind
+      end
+
+      def media_metadata(media, content_type)
+        {
+          "content_type" => content_type,
+          "byte_size" => media.size,
+          "filename" => media.original_filename
+        }
+      end
+
+      def media_placeholder(kind, filename)
+        return "[Photo]" if kind == "photo"
+
+        "[Document: #{filename}]"
+      end
+
+      def retry_photo_as_document?(error)
+        description = error.message.downcase
+        description.include?("bad request") &&
+          PHOTO_FALLBACK_EXCLUSIONS.none? { |reason| description.include?(reason) }
+      end
+
+      def download_url_for(attachment)
+        ActiveStorage::Current.set(
+          url_options: {
+            protocol: request.protocol,
+            host: request.host,
+            port: request.optional_port
+          }
+        ) do
+          attachment.blob.url(
+            expires_in: MEDIA_URL_TTL,
+            disposition: :attachment,
+            filename: attachment.filename
+          )
+        end
       end
 
     end

--- a/app/controllers/api/v1/telegram_messages_controller.rb
+++ b/app/controllers/api/v1/telegram_messages_controller.rb
@@ -8,7 +8,6 @@ module Api
       MAX_PHOTO_SIZE = 10.megabytes
       PHOTO_CONTENT_TYPES = %w[image/jpeg image/png].freeze
       PHOTO_FALLBACK_EXCLUSIONS = [ "blocked", "chat not found" ].freeze
-      MEDIA_URL_TTL = 5.minutes
 
       def create
         return render json: { error: "Telegram messaging is only available to agent API keys" }, status: :forbidden unless current_api_agent
@@ -38,7 +37,7 @@ module Api
 
           begin
             outbound_message = build_outbound_message(subscription, text, media, media_kind, content_type)
-            result = send_outbound_message(subscription, text, outbound_message)
+            result = send_outbound_message(subscription, text, outbound_message, media)
             record_outbound_message(outbound_message, result)
             delivered << subscriber_json(subscription)
           rescue TelegramNotifiable::TelegramError => e
@@ -120,15 +119,20 @@ module Api
         message
       end
 
-      def send_outbound_message(subscription, text, message)
+      def send_outbound_message(subscription, text, message, media)
         escaped_text = ERB::Util.html_escape(text)
         return current_api_agent.telegram_send_message(subscription.telegram_chat_id, escaped_text) unless message.media.attached?
 
-        media_url = download_url_for(message.media)
+        upload_options = {
+          filename: message.media.filename.to_s,
+          content_type: message.media.content_type,
+          caption: escaped_text.presence
+        }
+
         if message.photo?
-          current_api_agent.telegram_send_photo(subscription.telegram_chat_id, media_url, caption: escaped_text.presence)
+          current_api_agent.telegram_send_photo(subscription.telegram_chat_id, media.tempfile, **upload_options)
         else
-          current_api_agent.telegram_send_document(subscription.telegram_chat_id, media_url, caption: escaped_text.presence)
+          current_api_agent.telegram_send_document(subscription.telegram_chat_id, media.tempfile, **upload_options)
         end
       rescue TelegramNotifiable::TelegramError => error
         raise unless message.photo? && retry_photo_as_document?(error)
@@ -137,7 +141,7 @@ module Api
           media_kind: "document",
           text: text.presence || media_placeholder("document", message.media.filename.to_s)
         )
-        current_api_agent.telegram_send_document(subscription.telegram_chat_id, media_url, caption: escaped_text.presence)
+        current_api_agent.telegram_send_document(subscription.telegram_chat_id, media.tempfile, **upload_options)
       end
 
       def record_outbound_message(message, result)
@@ -183,22 +187,6 @@ module Api
         description = error.message.downcase
         description.include?("bad request") &&
           PHOTO_FALLBACK_EXCLUSIONS.none? { |reason| description.include?(reason) }
-      end
-
-      def download_url_for(attachment)
-        ActiveStorage::Current.set(
-          url_options: {
-            protocol: request.protocol,
-            host: request.host,
-            port: request.optional_port
-          }
-        ) do
-          attachment.blob.url(
-            expires_in: MEDIA_URL_TTL,
-            disposition: :attachment,
-            filename: attachment.filename
-          )
-        end
       end
 
     end

--- a/app/controllers/api/v1/telegram_messages_controller.rb
+++ b/app/controllers/api/v1/telegram_messages_controller.rb
@@ -101,7 +101,7 @@ module Api
           caption: text.presence,
           media_kind: media_kind,
           media_status: ("ready" if media.present?),
-          media_metadata: (media_metadata(media, content_type) if media.present?),
+          media_metadata: media.present? ? media_metadata(media, content_type) : {},
           sender_name: current_api_agent.name,
           sent_at: Time.current
         )

--- a/app/models/concerns/telegram_notifiable.rb
+++ b/app/models/concerns/telegram_notifiable.rb
@@ -36,6 +36,14 @@ module TelegramNotifiable
     result
   end
 
+  def telegram_send_photo(chat_id, photo, caption: nil)
+    telegram_send_media("sendPhoto", chat_id, :photo, photo, caption)
+  end
+
+  def telegram_send_document(chat_id, document, caption: nil)
+    telegram_send_media("sendDocument", chat_id, :document, document, caption)
+  end
+
   def telegram_file_info(file_id)
     result = telegram_api_request("getFile", { file_id: file_id })
     return result.fetch("result") if result["ok"] && result.dig("result", "file_path").present?
@@ -143,6 +151,16 @@ module TelegramNotifiable
   end
 
   private
+
+  def telegram_send_media(method, chat_id, media_key, media, caption)
+    body = { chat_id: chat_id, media_key => media }
+    body.merge!(caption: caption, parse_mode: "HTML") if caption.present?
+    result = telegram_api_request(method, body)
+
+    raise TelegramError, result["description"] unless result["ok"]
+
+    result
+  end
 
   def telegram_api_request(method, body)
     uri = URI("https://api.telegram.org/bot#{telegram_bot_token}/#{method}")

--- a/app/models/concerns/telegram_notifiable.rb
+++ b/app/models/concerns/telegram_notifiable.rb
@@ -36,12 +36,28 @@ module TelegramNotifiable
     result
   end
 
-  def telegram_send_photo(chat_id, photo, caption: nil)
-    telegram_send_media("sendPhoto", chat_id, :photo, photo, caption)
+  def telegram_send_photo(chat_id, photo, filename:, content_type:, caption: nil)
+    telegram_send_media(
+      "sendPhoto",
+      chat_id,
+      :photo,
+      photo,
+      filename: filename,
+      content_type: content_type,
+      caption: caption
+    )
   end
 
-  def telegram_send_document(chat_id, document, caption: nil)
-    telegram_send_media("sendDocument", chat_id, :document, document, caption)
+  def telegram_send_document(chat_id, document, filename:, content_type:, caption: nil)
+    telegram_send_media(
+      "sendDocument",
+      chat_id,
+      :document,
+      document,
+      filename: filename,
+      content_type: content_type,
+      caption: caption
+    )
   end
 
   def telegram_file_info(file_id)
@@ -152,10 +168,19 @@ module TelegramNotifiable
 
   private
 
-  def telegram_send_media(method, chat_id, media_key, media, caption)
-    body = { chat_id: chat_id, media_key => media }
-    body.merge!(caption: caption, parse_mode: "HTML") if caption.present?
-    result = telegram_api_request(method, body)
+  def telegram_send_media(method, chat_id, media_key, media, filename:, content_type:, caption:)
+    media.rewind
+    form = [ [ "chat_id", chat_id.to_s ] ]
+    form.concat([ [ "caption", caption ], [ "parse_mode", "HTML" ] ]) if caption.present?
+    form << [ media_key.to_s, media, { filename: filename, content_type: content_type } ]
+
+    uri = telegram_api_uri(method)
+    request = Net::HTTP::Post.new(uri)
+    request.set_form(form, "multipart/form-data")
+    response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: uri.scheme == "https") do |http|
+      http.request(request)
+    end
+    result = JSON.parse(response.body)
 
     raise TelegramError, result["description"] unless result["ok"]
 
@@ -163,9 +188,13 @@ module TelegramNotifiable
   end
 
   def telegram_api_request(method, body)
-    uri = URI("https://api.telegram.org/bot#{telegram_bot_token}/#{method}")
+    uri = telegram_api_uri(method)
     response = Net::HTTP.post(uri, body.to_json, "Content-Type" => "application/json")
     JSON.parse(response.body)
+  end
+
+  def telegram_api_uri(method)
+    URI("https://api.telegram.org/bot#{telegram_bot_token}/#{method}")
   end
 
   def set_telegram_webhook_token

--- a/app/models/telegram_message.rb
+++ b/app/models/telegram_message.rb
@@ -2,12 +2,13 @@ class TelegramMessage < ApplicationRecord
 
   include ObfuscatesId
 
-  MEDIA_KINDS = %w[photo voice video].freeze
+  MEDIA_KINDS = %w[photo voice video document].freeze
   MEDIA_STATUSES = %w[pending ready failed].freeze
   MEDIA_LIMITS = {
     "photo" => 20.megabytes,
     "voice" => 20.megabytes,
-    "video" => 20.megabytes
+    "video" => 20.megabytes,
+    "document" => 50.megabytes
   }.freeze
 
   belongs_to :telegram_subscription, touch: true
@@ -116,7 +117,7 @@ class TelegramMessage < ApplicationRecord
   private
 
   def media_placeholder
-    label = { "photo" => "Photo", "voice" => "Voice message", "video" => "Video" }.fetch(media_kind)
+    label = { "photo" => "Photo", "voice" => "Voice message", "video" => "Video", "document" => "Document" }.fetch(media_kind)
     return "[#{label} — processing]" if media_status == "pending"
     return "[#{label} could not be received]" if media_status == "failed"
 

--- a/test/controllers/api/v1/telegram_messages_controller_test.rb
+++ b/test/controllers/api/v1/telegram_messages_controller_test.rb
@@ -39,6 +39,7 @@ module Api
         assert_equal "assistant", telegram_message.role
         assert_equal "Hello <friend>", telegram_message.text
         assert_equal 77, telegram_message.telegram_message_id
+        assert_equal({}, telegram_message.media_metadata)
       end
 
       test "agent-scoped key can reply to a Telegram thread" do
@@ -56,10 +57,9 @@ module Api
       end
 
       test "agent-scoped key sends an attached image as a Telegram photo" do
-        posts = []
         fake_ok = OpenStruct.new(body: { "ok" => true, "result" => { "message_id" => 79 } }.to_json)
 
-        Net::HTTP.stub :post, ->(uri, body, headers) { posts << [ uri, JSON.parse(body), headers ]; fake_ok } do
+        requests = capture_multipart_requests(fake_ok) do
           post api_v1_telegram_messages_url,
             params: {
               recipient: "daniel",
@@ -70,10 +70,18 @@ module Api
         end
 
         assert_response :created
-        assert_equal 1, posts.length
-        assert_equal "https://api.telegram.org/bot#{@agent.telegram_bot_token}/sendPhoto", posts.first[0].to_s
-        assert_equal "A &lt;bright&gt; thing", posts.first[1]["caption"]
-        assert_match %r{/rails/active_storage/}, posts.first[1]["photo"]
+        assert_equal 1, requests.length
+        request = requests.first
+        assert_equal "/bot#{@agent.telegram_bot_token}/sendPhoto", request.path
+        assert_match %r{\Amultipart/form-data\z}, request.content_type
+        assert_equal "111", multipart_field(request, "chat_id")
+        assert_equal "A &lt;bright&gt; thing", multipart_field(request, "caption")
+        assert_equal "HTML", multipart_field(request, "parse_mode")
+
+        media = multipart_part(request, "photo")
+        assert_respond_to media[1], :read
+        assert_equal "test_image.png", media[2][:filename]
+        assert_equal "image/png", media[2][:content_type]
 
         telegram_message = @subscription.telegram_messages.last
         assert_equal "photo", telegram_message.media_kind
@@ -83,10 +91,9 @@ module Api
       end
 
       test "agent-scoped key sends an attachment without text" do
-        posts = []
         fake_ok = OpenStruct.new(body: { "ok" => true, "result" => { "message_id" => 80 } }.to_json)
 
-        Net::HTTP.stub :post, ->(uri, body, headers) { posts << [ uri, JSON.parse(body), headers ]; fake_ok } do
+        requests = capture_multipart_requests(fake_ok) do
           post api_v1_telegram_messages_url,
             params: {
               recipient: "daniel",
@@ -96,8 +103,14 @@ module Api
         end
 
         assert_response :created
-        assert_equal "https://api.telegram.org/bot#{@agent.telegram_bot_token}/sendDocument", posts.first[0].to_s
-        assert_nil posts.first[1]["caption"]
+        request = requests.first
+        assert_equal "/bot#{@agent.telegram_bot_token}/sendDocument", request.path
+        assert_nil multipart_field(request, "caption")
+
+        media = multipart_part(request, "document")
+        assert_respond_to media[1], :read
+        assert_equal "test.txt", media[2][:filename]
+        assert_equal "text/plain", media[2][:content_type]
 
         telegram_message = @subscription.telegram_messages.last
         assert_equal "document", telegram_message.media_kind
@@ -106,13 +119,12 @@ module Api
       end
 
       test "retries a rejected photo once as a document" do
-        posts = []
         responses = [
           OpenStruct.new(body: { "ok" => false, "description" => "Bad Request: PHOTO_INVALID_DIMENSIONS" }.to_json),
           OpenStruct.new(body: { "ok" => true, "result" => { "message_id" => 81 } }.to_json)
         ]
 
-        Net::HTTP.stub :post, ->(uri, body, headers) { posts << [ uri, JSON.parse(body), headers ]; responses.shift } do
+        requests = capture_multipart_requests(*responses) do
           post api_v1_telegram_messages_url,
             params: {
               recipient: "daniel",
@@ -122,9 +134,16 @@ module Api
         end
 
         assert_response :created
-        assert_equal 2, posts.length
-        assert_equal "https://api.telegram.org/bot#{@agent.telegram_bot_token}/sendPhoto", posts.first[0].to_s
-        assert_equal "https://api.telegram.org/bot#{@agent.telegram_bot_token}/sendDocument", posts.second[0].to_s
+        assert_equal 2, requests.length
+        assert_equal "/bot#{@agent.telegram_bot_token}/sendPhoto", requests.first.path
+        assert multipart_part(requests.first, "photo")
+        assert_operator requests.first.instance_variable_get(:@captured_upload_size), :>, 0
+        assert_equal "/bot#{@agent.telegram_bot_token}/sendDocument", requests.second.path
+        assert multipart_part(requests.second, "document")
+        assert_equal(
+          requests.first.instance_variable_get(:@captured_upload_size),
+          requests.second.instance_variable_get(:@captured_upload_size)
+        )
 
         telegram_message = @subscription.telegram_messages.last
         assert_equal "document", telegram_message.media_kind
@@ -172,6 +191,32 @@ module Api
           headers: { "Authorization" => "Bearer #{@token}" }
 
         assert_response :unprocessable_entity
+      end
+
+      private
+
+      def capture_multipart_requests(*responses)
+        requests = []
+        http = Object.new
+        http.define_singleton_method(:request) do |request|
+          upload = request.instance_variable_get(:@body_data).find { |part| part.length == 3 }
+          request.instance_variable_set(:@captured_upload_size, upload.second.read.bytesize)
+          requests << request
+          responses.shift
+        end
+
+        Net::HTTP.stub :start, ->(*_args, **_options, &block) { block.call(http) } do
+          yield
+        end
+        requests
+      end
+
+      def multipart_part(request, name)
+        request.instance_variable_get(:@body_data).find { |part| part.first == name }
+      end
+
+      def multipart_field(request, name)
+        multipart_part(request, name)&.second
       end
 
     end

--- a/test/controllers/api/v1/telegram_messages_controller_test.rb
+++ b/test/controllers/api/v1/telegram_messages_controller_test.rb
@@ -55,6 +55,97 @@ module Api
         assert_equal "Thread reply", @subscription.telegram_messages.last.text
       end
 
+      test "agent-scoped key sends an attached image as a Telegram photo" do
+        posts = []
+        fake_ok = OpenStruct.new(body: { "ok" => true, "result" => { "message_id" => 79 } }.to_json)
+
+        Net::HTTP.stub :post, ->(uri, body, headers) { posts << [ uri, JSON.parse(body), headers ]; fake_ok } do
+          post api_v1_telegram_messages_url,
+            params: {
+              recipient: "daniel",
+              text: "A <bright> thing",
+              media: fixture_file_upload("test_image.png", "image/png")
+            },
+            headers: { "Authorization" => "Bearer #{@token}" }
+        end
+
+        assert_response :created
+        assert_equal 1, posts.length
+        assert_equal "https://api.telegram.org/bot#{@agent.telegram_bot_token}/sendPhoto", posts.first[0].to_s
+        assert_equal "A &lt;bright&gt; thing", posts.first[1]["caption"]
+        assert_match %r{/rails/active_storage/}, posts.first[1]["photo"]
+
+        telegram_message = @subscription.telegram_messages.last
+        assert_equal "photo", telegram_message.media_kind
+        assert_equal "ready", telegram_message.media_status
+        assert_equal "A <bright> thing", telegram_message.text
+        assert telegram_message.media.attached?
+      end
+
+      test "agent-scoped key sends an attachment without text" do
+        posts = []
+        fake_ok = OpenStruct.new(body: { "ok" => true, "result" => { "message_id" => 80 } }.to_json)
+
+        Net::HTTP.stub :post, ->(uri, body, headers) { posts << [ uri, JSON.parse(body), headers ]; fake_ok } do
+          post api_v1_telegram_messages_url,
+            params: {
+              recipient: "daniel",
+              media: fixture_file_upload("test.txt", "text/plain")
+            },
+            headers: { "Authorization" => "Bearer #{@token}" }
+        end
+
+        assert_response :created
+        assert_equal "https://api.telegram.org/bot#{@agent.telegram_bot_token}/sendDocument", posts.first[0].to_s
+        assert_nil posts.first[1]["caption"]
+
+        telegram_message = @subscription.telegram_messages.last
+        assert_equal "document", telegram_message.media_kind
+        assert_equal "[Document: test.txt]", telegram_message.text
+        assert telegram_message.media.attached?
+      end
+
+      test "retries a rejected photo once as a document" do
+        posts = []
+        responses = [
+          OpenStruct.new(body: { "ok" => false, "description" => "Bad Request: PHOTO_INVALID_DIMENSIONS" }.to_json),
+          OpenStruct.new(body: { "ok" => true, "result" => { "message_id" => 81 } }.to_json)
+        ]
+
+        Net::HTTP.stub :post, ->(uri, body, headers) { posts << [ uri, JSON.parse(body), headers ]; responses.shift } do
+          post api_v1_telegram_messages_url,
+            params: {
+              recipient: "daniel",
+              media: fixture_file_upload("test_image.png", "image/png")
+            },
+            headers: { "Authorization" => "Bearer #{@token}" }
+        end
+
+        assert_response :created
+        assert_equal 2, posts.length
+        assert_equal "https://api.telegram.org/bot#{@agent.telegram_bot_token}/sendPhoto", posts.first[0].to_s
+        assert_equal "https://api.telegram.org/bot#{@agent.telegram_bot_token}/sendDocument", posts.second[0].to_s
+
+        telegram_message = @subscription.telegram_messages.last
+        assert_equal "document", telegram_message.media_kind
+        assert_equal "[Document: test_image.png]", telegram_message.text
+        assert_equal 81, telegram_message.telegram_message_id
+      end
+
+      test "rejects an overlong media caption before sending" do
+        post api_v1_telegram_messages_url,
+          params: {
+            recipient: "daniel",
+            text: "a" * 1_025,
+            media: fixture_file_upload("test_image.png", "image/png")
+          },
+          headers: { "Authorization" => "Bearer #{@token}" }
+
+        assert_response :unprocessable_entity
+        assert_equal "caption is too long (max 1024 characters)", JSON.parse(response.body)["error"]
+        assert_empty @subscription.telegram_messages
+      end
+
       test "user-scoped key cannot send telegram messages" do
         user_key = ApiKey.generate_for(@user, name: "User key")
 

--- a/test/lib/helixkit_send_telegram_test.rb
+++ b/test/lib/helixkit_send_telegram_test.rb
@@ -1,0 +1,123 @@
+require "test_helper"
+require "open3"
+require "socket"
+
+class HelixkitSendTelegramTest < ActiveSupport::TestCase
+
+  SCRIPT = Rails.root.join("agent-runtime/helixkit-send-telegram")
+
+  test "help documents attachments and the canonical runtime manual" do
+    stdout, stderr, status = Open3.capture3("python3", SCRIPT.to_s, "--help")
+
+    assert status.success?, stderr
+    assert_includes stdout, "--attach PATH"
+    assert_includes stdout, "/usr/local/share/helixkit-agent/helixkit-api.md"
+  end
+
+  test "posts a multipart Telegram attachment with an optional caption" do
+    request = capture_request do |url|
+      stdout, stderr, status = Open3.capture3(
+        {
+          "HELIXKIT_APP_URL" => url,
+          "HELIXKIT_BEARER_TOKEN" => "hx_test"
+        },
+        "python3",
+        SCRIPT.to_s,
+        "daniel",
+        "--attach",
+        file_fixture("test_image.png").to_s,
+        stdin_data: "A generated image\n"
+      )
+
+      assert status.success?, stderr
+      assert_includes stdout, "\"ok\":true"
+    end
+
+    assert_equal "POST /api/v1/telegram_messages HTTP/1.1", request[:request_line]
+    assert_equal "Bearer hx_test", request[:headers]["authorization"]
+    assert_match %r{\Amultipart/form-data; boundary=}, request[:headers]["content-type"]
+    assert_includes request[:body], 'name="recipient"'
+    assert_includes request[:body], "daniel"
+    assert_includes request[:body], 'name="text"'
+    assert_includes request[:body], "A generated image"
+    assert_includes request[:body], 'name="media"; filename="test_image.png"'
+    assert_includes request[:body], "Content-Type: image/png"
+  end
+
+  test "posts an attachment without message text" do
+    request = capture_request do |url|
+      _stdout, stderr, status = Open3.capture3(
+        {
+          "HELIXKIT_APP_URL" => url,
+          "HELIXKIT_BEARER_TOKEN" => "hx_test"
+        },
+        "python3",
+        SCRIPT.to_s,
+        "--reply-to",
+        "thread-123",
+        "--attach",
+        file_fixture("test_image.png").to_s,
+        stdin_data: ""
+      )
+
+      assert status.success?, stderr
+    end
+
+    assert_includes request[:body], 'name="reply_to"'
+    assert_includes request[:body], "thread-123"
+    assert_includes request[:body], 'name="media"; filename="test_image.png"'
+  end
+
+  test "keeps JSON for text-only messages" do
+    request = capture_request do |url|
+      _stdout, stderr, status = Open3.capture3(
+        {
+          "HELIXKIT_APP_URL" => url,
+          "HELIXKIT_BEARER_TOKEN" => "hx_test"
+        },
+        "python3",
+        SCRIPT.to_s,
+        "daniel",
+        stdin_data: "Text only"
+      )
+
+      assert status.success?, stderr
+    end
+
+    assert_equal "application/json", request[:headers]["content-type"]
+    assert_equal({ "text" => "Text only", "recipient" => "daniel" }, JSON.parse(request[:body]))
+  end
+
+  private
+
+  def capture_request
+    server = TCPServer.new("127.0.0.1", 0)
+    port = server.addr[1]
+    captured = Queue.new
+    thread = Thread.new do
+      socket = server.accept
+      request_line = socket.gets&.strip
+      headers = {}
+      while (line = socket.gets)
+        line = line.strip
+        break if line.empty?
+        name, value = line.split(":", 2)
+        headers[name.downcase] = value.to_s.strip
+      end
+      body = socket.read(headers.fetch("content-length", "0").to_i)
+      captured << { request_line: request_line, headers: headers, body: body }
+      payload = '{"ok":true}'
+      socket.write("HTTP/1.1 201 Created\r\nContent-Type: application/json\r\nContent-Length: #{payload.bytesize}\r\nConnection: close\r\n\r\n#{payload}")
+      socket.close
+    ensure
+      server.close
+    end
+
+    yield "http://127.0.0.1:#{port}"
+    captured.pop
+  ensure
+    thread&.join(2)
+    server&.close unless server&.closed?
+  end
+
+end


### PR DESCRIPTION
## Summary
- accept one optional multipart `media` upload on the outbound Telegram API
- upload eligible images as photos and other files as documents using Telegram multipart requests
- retain outbound attachments in Active Storage for conversation history
- retry Telegram photo `Bad Request` failures once as documents, rewinding the upload first
- add `helixkit-send-telegram --attach`, runtime documentation, and focused tests
- preserve the non-null media metadata default for text-only messages

## Validation
- `python3 -m py_compile agent-runtime/helixkit-send-telegram`
- `git diff --check`
- focused RuboCop: 5 files, no offenses
- focused attachment/model/helper tests: 18 runs, 109 assertions, 0 failures
- complete Telegram test slice: 95 runs, 335 assertions, 0 failures
- multipart tests verify file IO, filename, MIME type, captions, and photo-to-document rewind/retry behavior

The full 2,359-test Rails suite was also attempted with locally generated minimal test credentials. It reached completion, but unrelated tests requiring the repository's encrypted provider credentials and frontend build setup prevented a clean local full-suite result. The locked npm dependencies and Vite test assets were subsequently installed successfully; no failures occurred in the complete Telegram slice.