### PR TITLE
Prevent agent credentials from leaking into JSON

### DIFF
--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -43,6 +43,13 @@ class Agent < ApplicationRecord
     summary_prompt refinement_prompt refinement_threshold
     thinking_enabled thinking_budget enabled_tools
   ].freeze
+  SENSITIVE_JSON_ATTRIBUTES = %i[
+    github_deploy_key_priv outbound_api_token restic_password
+    telegram_bot_token telegram_webhook_token trigger_bearer_token
+  ].freeze
+  LIST_JSON_ATTRIBUTES = %i[
+    name model_id model_label active? paused? colour icon runtime health_state
+  ].freeze
 
   validates :name, presence: true,
                    length: { maximum: 100 },
@@ -92,16 +99,27 @@ class Agent < ApplicationRecord
                    :github_repo_url, :github_repo_owner, :github_repo_name,
                    :github_deploy_key_id, :container_name, :sandbox_host, :container_image,
                       :sandbox_last_error, :sandbox_last_error_at, :birth_committed_at,
-                      :provisioning_started_at, :identity_seeded_at, :runtime_ready_at,
-                      :orientation_requested_at, :orientation_completed_at,
-                      :orientation_last_error, :orientation_last_error_at, :oriented_at,
-                      :persistent_session?, :persistent_wake_session?, :scheduled_wakes_enabled?,
-                      :heartbeat_wakes_per_day
+                   :provisioning_started_at, :identity_seeded_at, :runtime_ready_at,
+                   :orientation_requested_at, :orientation_completed_at,
+                   :orientation_last_error, :orientation_last_error_at, :oriented_at,
+                   :persistent_session?, :persistent_wake_session?, :scheduled_wakes_enabled?,
+                       :heartbeat_wakes_per_day,
+                  except: SENSITIVE_JSON_ATTRIBUTES do |hash, options|
+    # Keep credentials out even if a caller supplies runtime serialization options
+    # that would otherwise override the configured `except` list.
+    hash.except!(*SENSITIVE_JSON_ATTRIBUTES.map(&:to_s))
+
+    if options&.dig(:as) == :list
+      hash.slice!("id", *LIST_JSON_ATTRIBUTES.map(&:to_s))
+    end
+
+    hash
+  end
 
   def self.json_attrs_for(options = nil)
     return json_attrs unless options&.dig(:as) == :list
 
-    json_attrs - [ :memories_count, :memory_token_summary ]
+    LIST_JSON_ATTRIBUTES
   end
 
   def model_label

--- a/test/controllers/chats_controller_test.rb
+++ b/test/controllers/chats_controller_test.rb
@@ -66,6 +66,28 @@ class ChatsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "group chat agent props use the safe list projection" do
+    agent = agents(:research_assistant)
+    agent.update!(
+      telegram_bot_token: "telegram-token",
+      trigger_bearer_token: "trigger-token"
+    )
+    group_chat = @account.chats.create!(
+      title: "Safe agent props",
+      manual_responses: true,
+      agents: [ agent ]
+    )
+
+    get account_chat_path(@account, group_chat)
+
+    agent_json = inertia_shared_props.fetch("agents").sole
+    assert_equal(
+      [ "active", "colour", "health_state", "icon", "id", "model_id", "model_label", "name", "paused", "runtime" ],
+      agent_json.keys.sort
+    )
+    assert_equal agent.to_param, agent_json.fetch("id")
+  end
+
   test "show includes conversation cost breakdown" do
     @chat.messages.create!(
       role: "assistant",

--- a/test/models/agent_test.rb
+++ b/test/models/agent_test.rb
@@ -59,6 +59,37 @@ class AgentTest < ActiveSupport::TestCase
     assert agent.active?
   end
 
+  test "json serialization never includes credential-bearing attributes" do
+    agent = agents(:research_assistant)
+    agent.update!(
+      github_deploy_key_priv: "private-key",
+      outbound_api_token: "outbound-token",
+      restic_password: "restic-password",
+      telegram_bot_token: "telegram-token",
+      telegram_webhook_token: "telegram-webhook-token",
+      trigger_bearer_token: "trigger-token"
+    )
+
+    [
+      agent.as_json,
+      agent.as_json(as: :list),
+      agent.as_json(only: [ :telegram_bot_token, :trigger_bearer_token ])
+    ].each do |json|
+      Agent::SENSITIVE_JSON_ATTRIBUTES.each do |attribute|
+        assert_not json.key?(attribute.to_s), "#{attribute} must not be serialized"
+      end
+    end
+  end
+
+  test "list json contains only fields used by agent pickers" do
+    agent = agents(:research_assistant)
+
+    assert_equal(
+      [ "active", "colour", "health_state", "icon", "id", "model_id", "model_label", "name", "paused", "runtime" ],
+      agent.as_json(as: :list).keys.sort
+    )
+  end
+
   test "defaults to twice-daily heartbeat wakes" do
     agent = @account.agents.create!(name: "Default Heartbeat Agent")
 


### PR DESCRIPTION
## Summary
- remove credential-bearing Agent attributes from every JSON representation
- make `as: :list` a minimal projection for chat and resident pickers
- add model and authenticated chat-page regression coverage

## Tests
- `bin/rails test` (2,362 runs, 11,333 assertions, 0 failures)
- `PARALLEL_WORKERS=1 bin/rails test test/models/agent_test.rb test/controllers/chats_controller_test.rb`
- `bin/rubocop app/models/agent.rb test/models/agent_test.rb test/controllers/chats_controller_test.rb`
- `git diff --check`

Repository-wide RuboCop still has six pre-existing layout offenses in unrelated files.